### PR TITLE
Reproducible layers, RC 0.7.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,9 +21,9 @@ jobs:
     -
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
+        go-version: 1.24
     -
-      uses: imjasonh/setup-crane@v0.3
+      uses: imjasonh/setup-crane@v0.4
     -
       uses: nolar/setup-k3d-k3s@v1.0.9
       with:

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Contain implements reproducible builds using deterministic layer creation:
 
 - **Timestamps**: All files and directories in layers use `SOURCE_DATE_EPOCH` (1970-01-01T00:00:00Z) for reproducible timestamps
 - **File Modes**: File permissions are normalized to 0644 for regular files and 0755 for directories by default
-- **Executable Preservation**: The executable bit (0111) is preserved from source files when present  
+- **Executable Preservation**: The executable bit (0111) is preserved from source files when present
 - **Mode Override**: Layer attributes can override the default file and directory modes
 - **Symlink Support**: Symbolic links pointing within the source tree are preserved with their target paths
 - **Directory Inclusion**: Directory entries are explicitly included in layers for complete filesystem representation
@@ -171,7 +171,7 @@ This enables reliable caching, content-addressable storage, and deterministic co
 This version introduces major changes for reproducible builds that affect layer digests:
 
 - **Breaking Change**: All layer digests will change due to normalized timestamps and file modes
-- **Test Updates Required**: ExpectDigest values in integration tests need updating  
+- **Test Updates Required**: ExpectDigest values in integration tests need updating
 - **Backward Compatibility**: Configuration remains compatible, only layer content changes
 - **Benefits**: Builds are now deterministic across environments and time
 

--- a/README.md
+++ b/README.md
@@ -126,3 +126,53 @@ Currently Contain can't update attestations. Those index entries are therefore d
 ## Configuration
 
 Contain supports template variables in config yaml using the framework from [Skaffold](https://skaffold.dev/docs/environment/templating/).
+
+## Reproducible Builds
+
+Contain implements reproducible builds using deterministic layer creation:
+
+- **Timestamps**: All files and directories in layers use `SOURCE_DATE_EPOCH` (1970-01-01T00:00:00Z) for reproducible timestamps
+- **File Modes**: File permissions are normalized to 0644 for regular files and 0755 for directories by default
+- **Executable Preservation**: The executable bit (0111) is preserved from source files when present  
+- **Mode Override**: Layer attributes can override the default file and directory modes
+- **Symlink Support**: Symbolic links pointing within the source tree are preserved with their target paths
+- **Directory Inclusion**: Directory entries are explicitly included in layers for complete filesystem representation
+
+### Mode Configuration
+
+You can override the default file and directory modes using layer attributes:
+
+```yaml
+layers:
+  - localDir:
+      path: ./build
+      containerPath: /app
+    layerAttributes:
+      mode: 0600        # Override file mode
+      dirMode: 0700     # Override directory mode
+      uid: 1000
+      gid: 1000
+```
+
+### Reproducible Layer Content
+
+The reproducible build implementation ensures that:
+
+1. **Identical source** produces **identical layers** regardless of build time or environment
+2. **File metadata** is normalized to prevent variations from filesystem differences
+3. **Directory structure** is completely captured including empty directories
+4. **Symlinks** are preserved when they point within the source tree
+5. **Build timestamps** do not affect layer checksums
+
+This enables reliable caching, content-addressable storage, and deterministic container image builds.
+
+## Migration to Reproducible Builds
+
+This version introduces major changes for reproducible builds that affect layer digests:
+
+- **Breaking Change**: All layer digests will change due to normalized timestamps and file modes
+- **Test Updates Required**: ExpectDigest values in integration tests need updating  
+- **Backward Compatibility**: Configuration remains compatible, only layer content changes
+- **Benefits**: Builds are now deterministic across environments and time
+
+To update existing configurations, simply rebuild your images - the functionality remains the same but with improved reproducibility guarantees.

--- a/jsonschema/config.json
+++ b/jsonschema/config.json
@@ -52,6 +52,9 @@
         },
         "mode": {
           "type": "integer"
+        },
+        "dirMode": {
+          "type": "integer"
         }
       },
       "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contain",
-  "version": "0.5.5",
+  "version": "0.7.0",
   "description": "Simple declarative container builds from local artifacts",
   "bin": {
     "contain": "bin/contain"
@@ -22,10 +22,10 @@
   },
   "homepage": "https://github.com/turbokube/contain#readme",
   "optionalDependencies": {
-    "contain-darwin-arm64": "0.5.5",
-    "contain-darwin-x64": "0.5.5",
-    "contain-linux-arm64": "0.5.5",
-    "contain-linux-x64": "0.5.5",
-    "contain-win32-x64": "0.5.5"
+    "contain-darwin-arm64": "0.7.0",
+    "contain-darwin-x64": "0.7.0",
+    "contain-linux-arm64": "0.7.0",
+    "contain-linux-x64": "0.7.0",
+    "contain-win32-x64": "0.7.0"
   }
 }

--- a/pkg/contain/testcases_test.go
+++ b/pkg/contain/testcases_test.go
@@ -45,7 +45,7 @@ var cases = []testcases.Testcase{
 				},
 			}
 		},
-		ExpectDigest: "sha256:5fbdcb2ac528ffe3aa2c5a7678d098b526eb7d3916d0bbee836549b0e20d746a",
+		ExpectDigest: "sha256:dc908b7cd7a7f4a65bf27f91986edcd2845dbc0ecdf84597b706d46680e77b3e",
 		Expect: func(ref contain.Artifact, t *testing.T) {
 
 			// double check base image digest

--- a/pkg/contain/testcases_test.go
+++ b/pkg/contain/testcases_test.go
@@ -45,7 +45,7 @@ var cases = []testcases.Testcase{
 				},
 			}
 		},
-		ExpectDigest: "sha256:dc908b7cd7a7f4a65bf27f91986edcd2845dbc0ecdf84597b706d46680e77b3e",
+		ExpectDigest: "sha256:77a0a91e7960a6e1a2bb9dfef4bcc2263e61e3d2134fa5ef410353111562b0bb",
 		Expect: func(ref contain.Artifact, t *testing.T) {
 
 			// double check base image digest
@@ -68,12 +68,12 @@ var cases = []testcases.Testcase{
 			Expect(manifest["schemaVersion"]).To(Equal(2.0))
 			Expect(manifest["mediaType"]).To(Equal("application/vnd.oci.image.manifest.v1+json"))
 			// layers := manifest["layers"].([]interface{})
-			Expect(raw).To(MatchJSON(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.image.config.v1+json","size":639,"digest":"sha256:e451487e9f07fa55dc57c2a59f0e964ee7e5b8a05d3cc81cb1392812d07929c3"},"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","size":80,"digest":"sha256:ac770dd5cf15356232a70ab6d2689e60b39b23fffe1c10955ba2681d32a4ad15","annotations":{"buildkit/rewritten-timestamp":"0"}},{"mediaType":"application/vnd.docker.image.rootfs.diff.tar.gzip","size":107,"digest":"sha256:6c9f141295d5636893db1435b5a20917860516e5e772445fb08bc240af66e57b"}]}`))
+			Expect(raw).To(MatchJSON(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.image.config.v1+json","size":639,"digest":"sha256:1b7c800e73c5206b46a15df24ba81496169526c9f5d64eb670543cd06a8064b2"},"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","size":80,"digest":"sha256:ac770dd5cf15356232a70ab6d2689e60b39b23fffe1c10955ba2681d32a4ad15","annotations":{"buildkit/rewritten-timestamp":"0"}},{"mediaType":"application/vnd.docker.image.rootfs.diff.tar.gzip","size":133,"digest":"sha256:bb39ec9bfaf0ea30cce59126c50d3f98e998f253887d0e4a7aae37ef074eb477"}]}`))
 
 			m, err := remote.Get(ref.Reference(), testCraneOptions.Remote...)
 			Expect(err).To(BeNil())
-			Expect(m.Digest.Hex).To(Equal("5fbdcb2ac528ffe3aa2c5a7678d098b526eb7d3916d0bbee836549b0e20d746a"))
-			Expect(m.RawManifest()).To(MatchJSON(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","size":611,"digest":"sha256:1c94651a07505a79ab6c6a330b1bb643e1ba5141216f276cddfc0bcef4a05f05","platform":{"architecture":"amd64","os":"linux"}},{"mediaType":"application/vnd.oci.image.manifest.v1+json","size":611,"digest":"sha256:d38cbbfbb5b8c33cc0f9eb47c559e7a12939644a28fd60c7e5119c0f62546dbe","platform":{"architecture":"arm64","os":"linux"}}]}`))
+			Expect(m.Digest.Hex).To(Equal("77a0a91e7960a6e1a2bb9dfef4bcc2263e61e3d2134fa5ef410353111562b0bb"))
+			Expect(m.RawManifest()).To(MatchJSON(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","size":611,"digest":"sha256:dc908b7cd7a7f4a65bf27f91986edcd2845dbc0ecdf84597b706d46680e77b3e","platform":{"architecture":"amd64","os":"linux"}},{"mediaType":"application/vnd.oci.image.manifest.v1+json","size":611,"digest":"sha256:76fa84b1b236161728fa95e8f68b299bec763320877ca2b1bd9241622cd40158","platform":{"architecture":"arm64","os":"linux"}}]}`))
 
 			amd64 := v1.Platform{Architecture: "amd64", OS: "linux"}
 			amd64options := append(testCraneOptions.Remote, remote.WithPlatform(amd64))
@@ -96,7 +96,7 @@ var cases = []testcases.Testcase{
 			if amd64cfg.Config.WorkingDir != "/" {
 				t.Errorf("workingdir %s", amd64cfg.Config.WorkingDir)
 			}
-			Expect(amd64config).To(MatchJSON(`{"architecture":"amd64","created":"1970-01-01T00:00:00Z","history":[{"created":"1970-01-01T00:00:00Z","created_by":"ARG TARGETARCH","comment":"buildkit.dockerfile.v0","empty_layer":true},{"created":"1970-01-01T00:00:00Z","created_by":"COPY ./amd64 / # buildkit","comment":"buildkit.dockerfile.v0"},{"created":"0001-01-01T00:00:00Z"}],"os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:294329baf7cfd56cfce463c90292879d44d563febc3f77a4c4f4ba8bf0e07a24","sha256:fc2b7873b55585e496924fc15d8fbb4286e708b3d2434bbe8fa1d1711953c151"]},"config":{"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"WorkingDir":"/"}}`))
+			Expect(amd64config).To(MatchJSON(`{"architecture":"amd64","created":"1970-01-01T00:00:00Z","history":[{"created":"1970-01-01T00:00:00Z","created_by":"ARG TARGETARCH","comment":"buildkit.dockerfile.v0","empty_layer":true},{"created":"1970-01-01T00:00:00Z","created_by":"COPY ./amd64 / # buildkit","comment":"buildkit.dockerfile.v0"},{"created":"0001-01-01T00:00:00Z"}],"os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:294329baf7cfd56cfce463c90292879d44d563febc3f77a4c4f4ba8bf0e07a24","sha256:a800f38d8d6b28428d0e23bc257e614ead7d9af4c80470d8771b5926b78c30a8"]},"config":{"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"WorkingDir":"/"}}`))
 
 			zap.L().Debug("amd64", zap.Int("layers", len(amd64layers)))
 
@@ -139,7 +139,7 @@ var cases = []testcases.Testcase{
 
 			a := fs["/app/root.txt"]
 			Expect(a).NotTo(BeNil(), "fs should contain file from the appended layer")
-			Expect(a.Mode == 420).To(BeTrue(), "should be -rw-r--r--")
+			Expect(a.Mode == 493).To(BeTrue(), "should be -rwxr-xr-x (executable bit preserved from source)")
 			Expect(a.ModTime).To(Equal(time.Unix(0, 0)))
 
 			arm64 := v1.Platform{Architecture: "arm64", OS: "linux"}
@@ -163,7 +163,7 @@ var cases = []testcases.Testcase{
 			if arm64cfg.Config.WorkingDir != "/" {
 				t.Errorf("workingdir %s", arm64cfg.Config.WorkingDir)
 			}
-			Expect(arm64config).To(MatchJSON(`{"architecture":"arm64","created":"1970-01-01T00:00:00Z","history":[{"created":"1970-01-01T00:00:00Z","created_by":"ARG TARGETARCH","comment":"buildkit.dockerfile.v0","empty_layer":true},{"created":"1970-01-01T00:00:00Z","created_by":"COPY ./arm64 / # buildkit","comment":"buildkit.dockerfile.v0"},{"created":"0001-01-01T00:00:00Z"}],"os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:716e2984b8fca92562cff105a2fe22f4f2abdfa6ae853b72024ea2f2d1741a39","sha256:fc2b7873b55585e496924fc15d8fbb4286e708b3d2434bbe8fa1d1711953c151"]},"config":{"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"WorkingDir":"/"}}`))
+			Expect(arm64config).To(MatchJSON(`{"architecture":"arm64","created":"1970-01-01T00:00:00Z","history":[{"created":"1970-01-01T00:00:00Z","created_by":"ARG TARGETARCH","comment":"buildkit.dockerfile.v0","empty_layer":true},{"created":"1970-01-01T00:00:00Z","created_by":"COPY ./arm64 / # buildkit","comment":"buildkit.dockerfile.v0"},{"created":"0001-01-01T00:00:00Z"}],"os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:716e2984b8fca92562cff105a2fe22f4f2abdfa6ae853b72024ea2f2d1741a39","sha256:a800f38d8d6b28428d0e23bc257e614ead7d9af4c80470d8771b5926b78c30a8"]},"config":{"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"WorkingDir":"/"}}`))
 
 			zap.L().Debug("arm64", zap.Int("layers", len(arm64layers)))
 			// we should assert on fs contents but we need an abstraction for the tar assertions above
@@ -186,7 +186,7 @@ var cases = []testcases.Testcase{
 				Platforms: []string{"linux/amd64"},
 			}
 		},
-		ExpectDigest: "sha256:dda9e675d63ac133fd541c076f3ba673beb70c3eee58dc603970929cea7a20b1",
+		ExpectDigest: "sha256:507f8b59b57dee95fd2e486b422a8f8941e0fac597d75e6de9901eb2fd63f543",
 		Expect: func(ref contain.Artifact, t *testing.T) {
 			img, err := remote.Get(ref.Reference(), testCraneOptions.Remote...)
 			Expect(err).To(BeNil())
@@ -212,7 +212,7 @@ var cases = []testcases.Testcase{
 				},
 			}
 		},
-		ExpectDigest: "sha256:b1f5d00014e713ed568b951280056828eb5ab6a3a90c9a73b0ea8e1d0749dc90",
+		ExpectDigest: "sha256:45cf77a6f6bd4fff38ceaa367add5ddca0f730c09d564e33bded2b067feb82a7",
 		Expect: func(ref contain.Artifact, t *testing.T) {
 			img, err := remote.Get(ref.Reference(), testCraneOptions.Remote...)
 			Expect(err).To(BeNil())
@@ -246,7 +246,7 @@ var cases = []testcases.Testcase{
 				},
 			}
 		},
-		ExpectDigest: "sha256:9f775563117d9c8da855934a95d5f99f419432d1f5a944f1f2f565a2693cbc6c",
+		ExpectDigest: "sha256:2996535982e1f220457d7726c88e3322e225a4ad01d84f4295ab176eb7da8a85",
 		Expect: func(ref contain.Artifact, t *testing.T) {
 			img, err := remote.Image(ref.Reference(), testCraneOptions.Remote...)
 			Expect(err).To(BeNil())

--- a/pkg/localdir/filemap_chmod.go
+++ b/pkg/localdir/filemap_chmod.go
@@ -6,7 +6,9 @@ import (
 	"archive/tar"
 	"bytes"
 	"io"
+	"os"
 	"sort"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -15,40 +17,91 @@ import (
 
 const (
 	defaultFileMode = int64(0644)
+	defaultDirMode  = int64(0755)
+	executableMask  = int64(0111) // mask to check executable bits
 )
+
+var (
+	// SOURCE_DATE_EPOCH is set to Unix epoch for reproducible builds
+	SOURCE_DATE_EPOCH = time.Unix(0, 0)
+)
+
+// FileInfo represents file metadata for tar layer creation
+type FileInfo struct {
+	Path     string
+	Content  []byte
+	Mode     os.FileMode
+	IsDir    bool
+	IsSymlink bool
+	LinkTarget string
+}
 
 // Layer creates a layer from a single file map. These layers are reproducible and consistent.
 // A filemap is a path -> file content map representing a file system.
 func Layer(filemap map[string][]byte, attributes schema.LayerAttributes) (v1.Layer, error) {
+	// Convert filemap to FileInfo for backward compatibility
+	var files []FileInfo
+	for path, content := range filemap {
+		files = append(files, FileInfo{
+			Path:    path,
+			Content: content,
+			Mode:    0644, // default file mode
+			IsDir:   false,
+			IsSymlink: false,
+		})
+	}
+	return LayerFromFiles(files, attributes)
+}
+
+// LayerFromFiles creates a layer from file metadata with proper mode and timestamp handling
+func LayerFromFiles(files []FileInfo, attributes schema.LayerAttributes) (v1.Layer, error) {
 	b := &bytes.Buffer{}
 	w := tar.NewWriter(b)
 
-	fn := []string{}
-	for f := range filemap {
-		fn = append(fn, f)
-	}
-	sort.Strings(fn)
+	// Sort by path for reproducible order
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
 
-	for _, f := range fn {
-		c := filemap[f]
-		mode := defaultFileMode
-		if attributes.FileMode != 0 {
-			mode = int64(attributes.FileMode)
+	for _, file := range files {
+		mode := calculateFileMode(file, attributes)
+		var typeflag byte = tar.TypeReg
+		
+		if file.IsSymlink {
+			typeflag = tar.TypeSymlink
+		} else if file.IsDir {
+			typeflag = tar.TypeDir
 		}
-		if err := w.WriteHeader(&tar.Header{
-			Name:     f,
-			Size:     int64(len(c)),
+
+		header := &tar.Header{
+			Name:     file.Path,
+			Mode:     mode,
 			Uid:      int(attributes.Uid),
 			Gid:      int(attributes.Gid),
-			Mode:     mode,
-			Typeflag: tar.TypeReg,
-		}); err != nil {
+			ModTime:  SOURCE_DATE_EPOCH,
+			Typeflag: typeflag,
+		}
+
+		if file.IsSymlink {
+			header.Linkname = file.LinkTarget
+			header.Size = 0
+		} else if file.IsDir {
+			header.Size = 0
+		} else {
+			header.Size = int64(len(file.Content))
+		}
+
+		if err := w.WriteHeader(header); err != nil {
 			return nil, err
 		}
-		if _, err := w.Write(c); err != nil {
-			return nil, err
+
+		if !file.IsDir && !file.IsSymlink {
+			if _, err := w.Write(file.Content); err != nil {
+				return nil, err
+			}
 		}
 	}
+
 	if err := w.Close(); err != nil {
 		return nil, err
 	}
@@ -57,4 +110,31 @@ func Layer(filemap map[string][]byte, attributes schema.LayerAttributes) (v1.Lay
 	return tarball.LayerFromOpener(func() (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewBuffer(b.Bytes())), nil
 	})
+}
+
+// calculateFileMode determines the appropriate file mode based on requirements:
+// - Use 0644 for files and 0755 for directories by default
+// - Preserve executable bit from source files
+// - Allow override via layer attributes
+func calculateFileMode(file FileInfo, attributes schema.LayerAttributes) int64 {
+	var mode int64
+
+	if file.IsDir {
+		mode = defaultDirMode
+		if attributes.DirMode != 0 {
+			mode = int64(attributes.DirMode)
+		}
+	} else {
+		mode = defaultFileMode
+		if attributes.FileMode != 0 {
+			mode = int64(attributes.FileMode)
+		} else {
+			// Preserve executable bit from source
+			if file.Mode&0111 != 0 {
+				mode = mode | executableMask
+			}
+		}
+	}
+
+	return mode
 }

--- a/pkg/localdir/filemap_chmod.go
+++ b/pkg/localdir/filemap_chmod.go
@@ -28,11 +28,11 @@ var (
 
 // FileInfo represents file metadata for tar layer creation
 type FileInfo struct {
-	Path     string
-	Content  []byte
-	Mode     os.FileMode
-	IsDir    bool
-	IsSymlink bool
+	Path       string
+	Content    []byte
+	Mode       os.FileMode
+	IsDir      bool
+	IsSymlink  bool
 	LinkTarget string
 }
 
@@ -43,10 +43,10 @@ func Layer(filemap map[string][]byte, attributes schema.LayerAttributes) (v1.Lay
 	var files []FileInfo
 	for path, content := range filemap {
 		files = append(files, FileInfo{
-			Path:    path,
-			Content: content,
-			Mode:    0644, // default file mode
-			IsDir:   false,
+			Path:      path,
+			Content:   content,
+			Mode:      0644, // default file mode
+			IsDir:     false,
 			IsSymlink: false,
 		})
 	}
@@ -66,7 +66,7 @@ func LayerFromFiles(files []FileInfo, attributes schema.LayerAttributes) (v1.Lay
 	for _, file := range files {
 		mode := calculateFileMode(file, attributes)
 		var typeflag byte = tar.TypeReg
-		
+
 		if file.IsSymlink {
 			typeflag = tar.TypeSymlink
 		} else if file.IsDir {

--- a/pkg/localdir/localdir.go
+++ b/pkg/localdir/localdir.go
@@ -119,10 +119,10 @@ func FromFilesystemWithMetadata(dir From, attributes schema.LayerAttributes) (v1
 					return err
 				}
 				files = append(files, FileInfo{
-					Path:    topath,
-					Content: nil,
-					Mode:    info.Mode(),
-					IsDir:   true,
+					Path:      topath,
+					Content:   nil,
+					Mode:      info.Mode(),
+					IsDir:     true,
 					IsSymlink: false,
 				})
 				seenDirs[topath] = true

--- a/pkg/localdir/localdir_test.go
+++ b/pkg/localdir/localdir_test.go
@@ -22,7 +22,7 @@ func debug(layer v1.Layer, t *testing.T) {
 		return
 	}
 	defer rc.Close()
-	
+
 	tr := tar.NewReader(rc)
 	t.Log("Layer contents:")
 	for {
@@ -35,7 +35,7 @@ func debug(layer v1.Layer, t *testing.T) {
 			break
 		}
 		t.Logf("  %s: mode=%o, uid=%d, gid=%d, size=%d, type=%c, modtime=%s",
-			header.Name, header.Mode, header.Uid, header.Gid, 
+			header.Name, header.Mode, header.Uid, header.Gid,
 			header.Size, header.Typeflag, header.ModTime.UTC())
 		if header.Typeflag == tar.TypeSymlink {
 			t.Logf("    -> symlink target: %s", header.Linkname)
@@ -185,7 +185,7 @@ func TestReproducibleBuilds(t *testing.T) {
 	// Verify timestamps are set to SOURCE_DATE_EPOCH
 	for name, header := range entries {
 		if !header.ModTime.Equal(localdir.SOURCE_DATE_EPOCH) {
-			t.Errorf("Entry %s has incorrect timestamp %v, expected %v", 
+			t.Errorf("Entry %s has incorrect timestamp %v, expected %v",
 				name, header.ModTime, localdir.SOURCE_DATE_EPOCH)
 		}
 	}
@@ -194,12 +194,12 @@ func TestReproducibleBuilds(t *testing.T) {
 	if entries["normal.txt"].Mode != 0644 {
 		t.Errorf("normal.txt should have mode 0644, got %o", entries["normal.txt"].Mode)
 	}
-	
+
 	// script.sh should preserve executable bit
 	if entries["script.sh"].Mode != 0755 {
 		t.Errorf("script.sh should have mode 0755 (preserving executable bit), got %o", entries["script.sh"].Mode)
 	}
-	
+
 	// symlink should be preserved
 	if entries["symlink.txt"].Typeflag != tar.TypeSymlink {
 		t.Errorf("symlink.txt should be a symlink, got typeflag %c", entries["symlink.txt"].Typeflag)
@@ -254,7 +254,7 @@ func TestModeOverrides(t *testing.T) {
 	if entries["normal.txt"].Mode != 0600 {
 		t.Errorf("normal.txt should have overridden mode 0600, got %o", entries["normal.txt"].Mode)
 	}
-	
+
 	if entries["."].Mode != 0700 {
 		t.Errorf("Directory should have overridden mode 0700, got %o", entries["."].Mode)
 	}
@@ -291,7 +291,7 @@ func TestReproducibleBuildsDeterministic(t *testing.T) {
 	}
 
 	if digest1.String() != digest2.String() {
-		t.Errorf("Layers should have identical digests for reproducible builds, got %s vs %s", 
+		t.Errorf("Layers should have identical digests for reproducible builds, got %s vs %s",
 			digest1.String(), digest2.String())
 	}
 

--- a/pkg/localdir/localdir_test.go
+++ b/pkg/localdir/localdir_test.go
@@ -1,6 +1,8 @@
 package localdir_test
 
 import (
+	"archive/tar"
+	"io"
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -13,7 +15,32 @@ import (
 )
 
 func debug(layer v1.Layer, t *testing.T) {
-	// not implemented
+	// Extract and examine the tar content to debug layer contents
+	rc, err := layer.Uncompressed()
+	if err != nil {
+		t.Errorf("Failed to get uncompressed layer: %v", err)
+		return
+	}
+	defer rc.Close()
+	
+	tr := tar.NewReader(rc)
+	t.Log("Layer contents:")
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Errorf("Error reading tar: %v", err)
+			break
+		}
+		t.Logf("  %s: mode=%o, uid=%d, gid=%d, size=%d, type=%c, modtime=%s",
+			header.Name, header.Mode, header.Uid, header.Gid, 
+			header.Size, header.Typeflag, header.ModTime.UTC())
+		if header.Typeflag == tar.TypeSymlink {
+			t.Logf("    -> symlink target: %s", header.Linkname)
+		}
+	}
 }
 
 func expectDigest(input localdir.From, digest string, t *testing.T) {
@@ -46,14 +73,15 @@ func TestFromFilesystemDir1(t *testing.T) {
 	undo := zap.ReplaceGlobals(logger)
 	defer undo()
 
+	// Updated expectations for reproducible builds
 	expectDigest(localdir.From{
 		Path: "./testdata/dir1",
-	}, "sha256:545dc99b3997be1f82cc1fc559ca9495e438eaf4d55d1827deb672cfc171504e", t)
+	}, "sha256:1e045563454a1b6dad232ebd8a466e8debf0d1d9c49c807d3e13e25a6dd3946b", t)
 
 	expectDigest(localdir.From{
 		Path:          "./testdata/dir1",
 		ContainerPath: localdir.NewPathMapperPrepend("/app"),
-	}, "sha256:5135d234403e9b548686de3a65ed302923b15a662e7a0a202efc2ea7d81d89e6", t)
+	}, "sha256:fe7dfab2d0a720ae7271d16ff803544d01bfa08ed87c613383a2664b45e88125", t)
 
 	ignoreA, err := patternmatcher.New([]string{"a.*"})
 	if err != nil {
@@ -63,7 +91,7 @@ func TestFromFilesystemDir1(t *testing.T) {
 		Path:          "./testdata/dir1",
 		ContainerPath: localdir.NewPathMapperPrepend("/app"),
 		Ignore:        ignoreA,
-	}, "sha256:fad4816a0e3821e9f23b6b4a9b2003d201ce17ad67ccb1b28734c0ed675dad7b", t)
+	}, "sha256:befccdb1423b50fdf5691e8126c80b875d449340c31ef5efd9a97cd1a0ee707c", t)
 
 	ignoreAll, err := patternmatcher.New([]string{"*"})
 	if err != nil {
@@ -83,19 +111,19 @@ func TestFromFilesystemDir1(t *testing.T) {
 
 	expectDigest(localdir.From{
 		Path: "./testdata/dir2",
-	}, "sha256:a7466234676e9d24fe2f8dc6d08e1b7ed1f5c17151e2d62687275f1d76cf3c68", t)
+	}, "sha256:85ce5400f21fc875bcf575243ae29db958d07699b07eb6d00f532e9e1d806bda", t)
 
 	expectDigestWithAttributes(schema.LayerAttributes{FileMode: 0755}, localdir.From{
 		Path: "./testdata/dir2",
-	}, "sha256:20ca46c26fe5c9d7a81cd2509e9e9e0ca4cfd639940b9fe82c9bdc113a5bbaa0", t)
+	}, "sha256:7f7f123e57c33d58d0efc1d1973852b4e981eece16209a4eab939138ea711140", t)
 
 	expectDigestWithAttributes(schema.LayerAttributes{Uid: 65532}, localdir.From{
 		Path: "./testdata/dir2",
-	}, "sha256:cf729c44714cc4528d6f70f67cbe82358f55966a2168084149a94b00598b2b89", t)
+	}, "sha256:b879074782a944a7699c32cefc4d76ec99c480f953735dd33166e4083de928bc", t)
 
 	expectDigestWithAttributes(schema.LayerAttributes{Gid: 65534}, localdir.From{
 		Path: "./testdata/dir2",
-	}, "sha256:b9ef15618528091f7ead6945df474d60cb2930c22abac1267a6759d8e6d68e70", t)
+	}, "sha256:d732c7242056913aaa8195a11d009cdceb843058c616d8dec4659927e6209984", t)
 
 }
 
@@ -110,4 +138,162 @@ func TestNewPathMapperPrepend(t *testing.T) {
 	mapper := localdir.NewPathMapperPrepend("/prep")
 	Expect(mapper("t")).To(Equal("/prep/t"))
 	Expect(mapper(".")).To(Equal("/prep"))
+}
+
+func TestReproducibleBuilds(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
+	undo := zap.ReplaceGlobals(logger)
+	defer undo()
+
+	// Test that timestamps are set to SOURCE_DATE_EPOCH
+	layer, err := localdir.FromFilesystem(localdir.From{
+		Path: "./testdata/reproducible",
+	}, schema.LayerAttributes{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify layer structure includes directories and proper timestamps
+	rc, err := layer.Uncompressed()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+
+	tr := tar.NewReader(rc)
+	entries := make(map[string]*tar.Header)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries[header.Name] = header
+	}
+
+	// Check that we have the expected entries
+	expectedEntries := []string{".", "normal.txt", "script.sh", "symlink.txt"}
+	for _, expected := range expectedEntries {
+		if _, exists := entries[expected]; !exists {
+			t.Errorf("Expected entry %s not found in layer", expected)
+		}
+	}
+
+	// Verify timestamps are set to SOURCE_DATE_EPOCH
+	for name, header := range entries {
+		if !header.ModTime.Equal(localdir.SOURCE_DATE_EPOCH) {
+			t.Errorf("Entry %s has incorrect timestamp %v, expected %v", 
+				name, header.ModTime, localdir.SOURCE_DATE_EPOCH)
+		}
+	}
+
+	// Verify file modes
+	if entries["normal.txt"].Mode != 0644 {
+		t.Errorf("normal.txt should have mode 0644, got %o", entries["normal.txt"].Mode)
+	}
+	
+	// script.sh should preserve executable bit
+	if entries["script.sh"].Mode != 0755 {
+		t.Errorf("script.sh should have mode 0755 (preserving executable bit), got %o", entries["script.sh"].Mode)
+	}
+	
+	// symlink should be preserved
+	if entries["symlink.txt"].Typeflag != tar.TypeSymlink {
+		t.Errorf("symlink.txt should be a symlink, got typeflag %c", entries["symlink.txt"].Typeflag)
+	}
+	if entries["symlink.txt"].Linkname != "normal.txt" {
+		t.Errorf("symlink.txt should link to normal.txt, got %s", entries["symlink.txt"].Linkname)
+	}
+
+	// Directory should have proper mode
+	if entries["."].Mode != 0755 {
+		t.Errorf("Directory should have mode 0755, got %o", entries["."].Mode)
+	}
+}
+
+func TestModeOverrides(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync()
+	undo := zap.ReplaceGlobals(logger)
+	defer undo()
+
+	// Test file mode override
+	layer, err := localdir.FromFilesystem(localdir.From{
+		Path: "./testdata/reproducible",
+	}, schema.LayerAttributes{
+		FileMode: 0600,
+		DirMode:  0700,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rc, err := layer.Uncompressed()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+
+	tr := tar.NewReader(rc)
+	entries := make(map[string]*tar.Header)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries[header.Name] = header
+	}
+
+	// Verify overridden modes
+	if entries["normal.txt"].Mode != 0600 {
+		t.Errorf("normal.txt should have overridden mode 0600, got %o", entries["normal.txt"].Mode)
+	}
+	
+	if entries["."].Mode != 0700 {
+		t.Errorf("Directory should have overridden mode 0700, got %o", entries["."].Mode)
+	}
+}
+
+func TestReproducibleBuildsDeterministic(t *testing.T) {
+	logger := zap.NewNop()
+	undo := zap.ReplaceGlobals(logger)
+	defer undo()
+
+	// Create the same layer twice and verify identical digests
+	layer1, err := localdir.FromFilesystem(localdir.From{
+		Path: "./testdata/reproducible",
+	}, schema.LayerAttributes{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	layer2, err := localdir.FromFilesystem(localdir.From{
+		Path: "./testdata/reproducible",
+	}, schema.LayerAttributes{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	digest1, err := layer1.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	digest2, err := layer2.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if digest1.String() != digest2.String() {
+		t.Errorf("Layers should have identical digests for reproducible builds, got %s vs %s", 
+			digest1.String(), digest2.String())
+	}
+
+	t.Logf("Reproducible digest: %s", digest1.String())
 }

--- a/pkg/localdir/testdata/reproducible/normal.txt
+++ b/pkg/localdir/testdata/reproducible/normal.txt
@@ -1,0 +1,1 @@
+test file

--- a/pkg/localdir/testdata/reproducible/script.sh
+++ b/pkg/localdir/testdata/reproducible/script.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo hello

--- a/pkg/localdir/testdata/reproducible/symlink.txt
+++ b/pkg/localdir/testdata/reproducible/symlink.txt
@@ -1,0 +1,1 @@
+normal.txt

--- a/pkg/schema/v1/config.go
+++ b/pkg/schema/v1/config.go
@@ -45,7 +45,14 @@ type LayerAttributes struct {
 
 	// Mode bits to use on files, must be a value between 0 and 0777.
 	// YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+	// Note that if you don't specify mode, contain will try to preserve local mode which might void reproducibility.
 	FileMode int32 `json:"mode,omitempty"`
+
+	// DirMode bits to use on directories, must be a value between 0 and 0777.
+	// If not specified, the mode value will be used for directories as well.
+	// YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+	// Note that if you don't specify mode, contain will try to preserve local mode which might void reproducibility.
+	DirMode int32 `json:"dirMode,omitempty"`
 }
 
 // LocalFile is a single file that should be appended as-is to base

--- a/pkg/schema/v1/config.go
+++ b/pkg/schema/v1/config.go
@@ -38,20 +38,22 @@ type Layer struct {
 	LocalFile LocalFile `json:"localFile,omitempty"`
 }
 
+// LayerAttributes defines is generic and some layer types may ignore some of the fields.
 type LayerAttributes struct {
-	// generic, supported for applicable layer types
+	// Uid sets file and directory owner, default is 0 (root).
 	Uid uint16 `json:"uid,omitempty"`
+	// Gid sets file and directory group, default is 0 (root).
 	Gid uint16 `json:"gid,omitempty"`
 
 	// Mode bits to use on files, must be a value between 0 and 0777.
 	// YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-	// Note that if you don't specify mode, contain will try to preserve local mode which might void reproducibility.
+	// Default is 0644.
 	FileMode int32 `json:"mode,omitempty"`
 
 	// DirMode bits to use on directories, must be a value between 0 and 0777.
 	// If not specified, the mode value will be used for directories as well.
 	// YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-	// Note that if you don't specify mode, contain will try to preserve local mode which might void reproducibility.
+	// Default is 0755.
 	DirMode int32 `json:"dirMode,omitempty"`
 }
 

--- a/scripts/publish.go
+++ b/scripts/publish.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	publishVersion    = "0.5.5"
+	publishVersion    = "0.7.0"
 	releaseBinaryName = regexp.MustCompile(`^contain-v(?P<version>\d+\.\d+\.\d+)-(?P<os>[a-z0-9]+)-(?P<arch>[a-z0-9]+)(?P<ext>\.exe)?(?P<checksum>\.[a-z0-9]+)?$`)
 )
 

--- a/test/filemode.test.yaml
+++ b/test/filemode.test.yaml
@@ -4,14 +4,14 @@ fileExistenceTests:
   path: '/filemode'
   shouldExist: true
   permissions: 'drwxr-xr-x'
-  uid: 0
-  gid: 0
+  uid: 65532
+  gid: 65534
 - name: 'subdir'
   path: '/filemode/subdir'
   shouldExist: true
   permissions: 'drwxr-xr-x'
-  uid:
-  gid: 0
+  uid: 65532
+  gid: 65534
 - name: 'a.txt'
   path: '/filemode/a.txt'
   shouldExist: true


### PR DESCRIPTION
Reimplements #6 #7 #8 using Claude Sonnet 4 because the previous impl was never merged and I'm more confident with Claude 4's output quality.

This was the spec:

I need to make major changes to how local source is converted to layers.
The purpose is reproducible builds.
I expect all ExpectDigest values to change in tests,
which is why unit testing must be improved as part of this effort
to assert on actual layer content and then use the checksum as a last
step that verifies that we do have reproducible builds.

The changes to make are:
- file and dir mode should _never_ be preserved from source, except the executable bit of files.
- default will be 0644 for files and 0755 for directories.
- new config for localDir and localFile will be added to override mode per layer
- symlinks should be preserved in source structure, if pointing to any other entry in the same source tree.
- all file and dir timestamps should be set to 1970-01-01T00:00:00Z,
  using a const named SOURCE_DATE_EPOCH.

Use ./test.sh as devloop to include the full set of tests.
Note that the script builds the binary it uses.

Add new chapters to the end of README.md while working.