### PR TITLE
Limit push concurrency using --push-lock or CONTAIN_PUSH_LOCK_PATH 

### DIFF
--- a/cmd/contain/build.go
+++ b/cmd/contain/build.go
@@ -249,22 +249,44 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		zap.L().Info("output from env", zap.String("CONTAIN_OCI_OUTPUT", ociEnv.Path))
 	}
 
-	// Push lock: flag takes precedence over env
-	effectivePushLockPath := pushLockPath
-	if effectivePushLockPath == "" {
+	// Push lock: --push-lock flag overrides CONTAIN_PUSH_LOCK_PATH env.
+	// --push-lock= or --push-lock=/dev/null explicitly disables locking.
+	var plock pushlock.PushLock
+	pushLockFlagChanged := cmd.Flags().Lookup("push-lock") != nil && cmd.Flags().Changed("push-lock")
+	if pushLockFlagChanged {
+		envPath, _ := containenv.PushLockPath()
+		if pushLockPath == "" || pushLockPath == "/dev/null" {
+			if envPath != "" {
+				zap.L().Info("push lock disabled by flag, overriding env",
+					zap.String("CONTAIN_PUSH_LOCK_PATH", envPath),
+					zap.String("--push-lock", pushLockPath),
+				)
+			}
+		} else {
+			if envPath != "" && envPath != pushLockPath {
+				zap.L().Info("push lock path from flag, overriding env",
+					zap.String("CONTAIN_PUSH_LOCK_PATH", envPath),
+					zap.String("--push-lock", pushLockPath),
+				)
+			}
+			pl, err := pushlock.NewFlockPushLock(pushLockPath, zap.L())
+			if err != nil {
+				return err
+			}
+			plock = pl
+		}
+	} else {
 		envPath, err := containenv.PushLockPath()
 		if err != nil {
 			return err
 		}
-		effectivePushLockPath = envPath
-	}
-	var plock pushlock.PushLock
-	if effectivePushLockPath != "" {
-		pl, err := pushlock.NewFlockPushLock(effectivePushLockPath, zap.L())
-		if err != nil {
-			return err
+		if envPath != "" {
+			pl, err := pushlock.NewFlockPushLock(envPath, zap.L())
+			if err != nil {
+				return err
+			}
+			plock = pl
 		}
-		plock = pl
 	}
 
 	buildOutput, err := contain.RunAppend(config, layers, contain.WriteOptions{

--- a/cmd/contain/build.go
+++ b/cmd/contain/build.go
@@ -14,6 +14,7 @@ import (
 	"github.com/turbokube/contain/pkg/contain"
 	containenv "github.com/turbokube/contain/pkg/env"
 	"github.com/turbokube/contain/pkg/pushed"
+	"github.com/turbokube/contain/pkg/pushlock"
 	"github.com/turbokube/contain/pkg/sbom"
 	"github.com/turbokube/contain/pkg/run"
 	"github.com/turbokube/contain/pkg/schema"
@@ -40,6 +41,7 @@ var (
 	outputPath   string
 	outputFormat string
 	pushFlag     bool
+	pushLockPath string
 )
 
 // newBuildCmd defines the build subcommand and its flags
@@ -67,6 +69,7 @@ func newBuildCmd() *cobra.Command {
 	c.Flags().StringVar(&outputPath, "output", "", "write image to this path (format selected by --format)")
 	c.Flags().StringVar(&outputFormat, "format", "oci", `output format: "oci" or "tarball" (as in crane pull --format)`)
 	c.Flags().BoolVar(&pushFlag, "push", true, "push image to registry")
+	c.Flags().StringVar(&pushLockPath, "push-lock", "", "absolute path to flock file for serializing pushes across processes")
 	c.Flags().StringVar(&sbomInFile, "sbom-in", "", "path to SPDX file for the contents of the build")
 	c.Flags().StringVar(&sbomOutFile, "sbom-out", "", "path to SPDX file to write (same as in to overwrite)")
 	return c
@@ -246,10 +249,29 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		zap.L().Info("output from env", zap.String("CONTAIN_OCI_OUTPUT", ociEnv.Path))
 	}
 
+	// Push lock: flag takes precedence over env
+	effectivePushLockPath := pushLockPath
+	if effectivePushLockPath == "" {
+		envPath, err := containenv.PushLockPath()
+		if err != nil {
+			return err
+		}
+		effectivePushLockPath = envPath
+	}
+	var plock pushlock.PushLock
+	if effectivePushLockPath != "" {
+		pl, err := pushlock.NewFlockPushLock(effectivePushLockPath, zap.L())
+		if err != nil {
+			return err
+		}
+		plock = pl
+	}
+
 	buildOutput, err := contain.RunAppend(config, layers, contain.WriteOptions{
 		Push:         pushFlag,
 		OutputPath:   effectiveOutput,
 		OutputFormat: effectiveFormat,
+		PushLock:     plock,
 	})
 	if err != nil {
 		zap.L().Fatal("append", zap.Error(err))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contain",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Simple declarative container builds from local artifacts",
   "bin": {
     "contain": "bin/contain"
@@ -22,10 +22,10 @@
   },
   "homepage": "https://github.com/turbokube/contain#readme",
   "optionalDependencies": {
-    "contain-darwin-arm64": "0.7.8",
-    "contain-darwin-x64": "0.7.8",
-    "contain-linux-arm64": "0.7.8",
-    "contain-linux-x64": "0.7.8",
-    "contain-win32-x64": "0.7.8"
+    "contain-darwin-arm64": "0.7.9",
+    "contain-darwin-x64": "0.7.9",
+    "contain-linux-arm64": "0.7.9",
+    "contain-linux-x64": "0.7.9",
+    "contain-win32-x64": "0.7.9"
   }
 }

--- a/pkg/appender/appender_remote.go
+++ b/pkg/appender/appender_remote.go
@@ -3,6 +3,7 @@
 package appender
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/turbokube/contain/pkg/annotate"
+	"github.com/turbokube/contain/pkg/pushlock"
 	"github.com/turbokube/contain/pkg/registry"
 	"go.uber.org/zap"
 )
@@ -36,6 +38,8 @@ type Appender struct {
 	args []string
 	// skipPush skips pushing the image to the registry
 	skipPush bool
+	// pushLock serializes push operations across processes
+	pushLock pushlock.PushLock
 }
 
 type AppendAnnotate func(partial.WithRawManifest) v1.Image
@@ -129,6 +133,11 @@ func (c *Appender) WithSkipPush(skip bool) {
 	c.skipPush = skip
 }
 
+// WithPushLock sets an optional lock to serialize push operations across processes.
+func (c *Appender) WithPushLock(lock pushlock.PushLock) {
+	c.pushLock = lock
+}
+
 func (c *Appender) getPushConfig() *registry.RegistryConfig {
 	return c.baseConfig
 }
@@ -209,6 +218,14 @@ func (c *Appender) Append(layers ...v1.Layer) (AppendResult, error) {
 		return AppendResultNone, err
 	}
 	if !c.skipPush {
+		if c.pushLock != nil {
+			release, lockErr := c.pushLock.Acquire(context.Background())
+			if lockErr != nil {
+				zap.L().Error("push lock acquire", zap.Error(lockErr))
+				return AppendResultNone, lockErr
+			}
+			defer release()
+		}
 		err = c.push(img)
 		if err != nil {
 			zap.L().Error("Failed to push", zap.Error(err))

--- a/pkg/contain/libcontain.go
+++ b/pkg/contain/libcontain.go
@@ -11,6 +11,7 @@ import (
 	"github.com/turbokube/contain/pkg/layers"
 	"github.com/turbokube/contain/pkg/multiarch"
 	"github.com/turbokube/contain/pkg/pushed"
+	"github.com/turbokube/contain/pkg/pushlock"
 	"github.com/turbokube/contain/pkg/registry"
 	schemav1 "github.com/turbokube/contain/pkg/schema/v1"
 	"go.uber.org/zap"
@@ -24,6 +25,8 @@ type WriteOptions struct {
 	OutputPath string
 	// OutputFormat selects the output format: "tarball" (default) or "oci".
 	OutputFormat OutputFormat
+	// PushLock, if non-nil, serializes push operations across processes.
+	PushLock pushlock.PushLock
 }
 
 // Run is what you call if you have a complete config and want to push an artifact
@@ -119,6 +122,9 @@ func RunAppend(config schemav1.ContainConfig, layers []v1.Layer, opts WriteOptio
 			return mutate.IndexAddendum{}, err
 		}
 		a.WithSkipPush(!opts.Push)
+		if opts.PushLock != nil {
+			a.WithPushLock(opts.PushLock)
+		}
 		// Apply env overrides/additions if configured
 		if len(config.Env) > 0 {
 			var envs []string

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 )
 
 // PushOption returns the value of CONTAIN_PUSH as a *bool.
@@ -35,6 +36,10 @@ func OCIOutput() (*OCIOutputOption, error) {
 	}
 	if filepath.IsAbs(v) {
 		return nil, fmt.Errorf("CONTAIN_OCI_OUTPUT must be a relative path, got %q", v)
+	}
+	cleaned := filepath.Clean(v)
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("CONTAIN_OCI_OUTPUT must not escape the working directory, got %q", v)
 	}
 	return &OCIOutputOption{Path: v}, nil
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -39,6 +39,19 @@ func OCIOutput() (*OCIOutputOption, error) {
 	return &OCIOutputOption{Path: v}, nil
 }
 
+// PushLockPath returns the value of CONTAIN_PUSH_LOCK_PATH if set.
+// Returns error if the path is not absolute.
+func PushLockPath() (string, error) {
+	v, ok := os.LookupEnv("CONTAIN_PUSH_LOCK_PATH")
+	if !ok || v == "" {
+		return "", nil
+	}
+	if !filepath.IsAbs(v) {
+		return "", fmt.Errorf("CONTAIN_PUSH_LOCK_PATH must be absolute, got %q", v)
+	}
+	return v, nil
+}
+
 // TurboHash returns the value of TURBO_HASH if set, empty string otherwise.
 func TurboHash() string {
 	return os.Getenv("TURBO_HASH")

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -100,6 +100,30 @@ func TestOCIOutput_RelativeNested(t *testing.T) {
 	}
 }
 
+func TestOCIOutput_ParentTraversal(t *testing.T) {
+	t.Setenv("CONTAIN_OCI_OUTPUT", "../escape")
+	_, err := OCIOutput()
+	if err == nil {
+		t.Fatal("expected error for ../ path")
+	}
+}
+
+func TestOCIOutput_ParentTraversalNested(t *testing.T) {
+	t.Setenv("CONTAIN_OCI_OUTPUT", "foo/../../escape")
+	_, err := OCIOutput()
+	if err == nil {
+		t.Fatal("expected error for path escaping via nested ../")
+	}
+}
+
+func TestOCIOutput_ParentOnly(t *testing.T) {
+	t.Setenv("CONTAIN_OCI_OUTPUT", "..")
+	_, err := OCIOutput()
+	if err == nil {
+		t.Fatal("expected error for bare ..")
+	}
+}
+
 func TestOCIOutput_Absolute(t *testing.T) {
 	t.Setenv("CONTAIN_OCI_OUTPUT", "/tmp/oci-out")
 	_, err := OCIOutput()

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -119,6 +119,46 @@ func TestOCIOutput_Empty(t *testing.T) {
 	}
 }
 
+func TestPushLockPath_NotSet(t *testing.T) {
+	v, err := PushLockPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != "" {
+		t.Fatalf("expected empty, got %s", v)
+	}
+}
+
+func TestPushLockPath_Absolute(t *testing.T) {
+	t.Setenv("CONTAIN_PUSH_LOCK_PATH", "/tmp/contain-push.lock")
+	v, err := PushLockPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != "/tmp/contain-push.lock" {
+		t.Fatalf("expected /tmp/contain-push.lock, got %s", v)
+	}
+}
+
+func TestPushLockPath_Relative(t *testing.T) {
+	t.Setenv("CONTAIN_PUSH_LOCK_PATH", "relative.lock")
+	_, err := PushLockPath()
+	if err == nil {
+		t.Fatal("expected error for relative path")
+	}
+}
+
+func TestPushLockPath_Empty(t *testing.T) {
+	t.Setenv("CONTAIN_PUSH_LOCK_PATH", "")
+	v, err := PushLockPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != "" {
+		t.Fatalf("expected empty, got %s", v)
+	}
+}
+
 func TestTurboHash_NotSet(t *testing.T) {
 	h := TurboHash()
 	if h != "" {

--- a/pkg/pushlock/flock_unix.go
+++ b/pkg/pushlock/flock_unix.go
@@ -1,0 +1,73 @@
+//go:build !windows
+
+package pushlock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func validateAbsPath(path string) error {
+	if path[0] != '/' {
+		return fmt.Errorf("push lock path must be absolute, got %q", path)
+	}
+	return nil
+}
+
+// Acquire blocks until the flock is obtained. While waiting, it reads
+// the lock file to log who currently holds the lock.
+func (l *FlockPushLock) Acquire(ctx context.Context) (func(), error) {
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("push lock open %s: %w", l.path, err)
+	}
+
+	start := time.Now()
+
+	// Try non-blocking first
+	err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		// Lock is held by another process, log who
+		holder := readHolder(f)
+		l.logger.Info("push lock waiting",
+			zap.String("path", l.path),
+			zap.String("holder", holder),
+		)
+
+		// Block until acquired, checking context in a goroutine
+		acquired := make(chan error, 1)
+		go func() {
+			acquired <- syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+		}()
+
+		select {
+		case err = <-acquired:
+			if err != nil {
+				f.Close()
+				return nil, fmt.Errorf("push lock flock %s: %w", l.path, err)
+			}
+		case <-ctx.Done():
+			f.Close()
+			return nil, ctx.Err()
+		}
+
+		l.logger.Info("push lock acquired",
+			zap.String("path", l.path),
+			zap.Duration("waited", time.Since(start)),
+		)
+	}
+
+	// Write metadata about current holder
+	writeHolder(f)
+
+	release := func() {
+		syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		f.Close()
+	}
+	return release, nil
+}

--- a/pkg/pushlock/flock_windows.go
+++ b/pkg/pushlock/flock_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package pushlock
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+)
+
+func validateAbsPath(path string) error {
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("push lock path must be absolute, got %q", path)
+	}
+	return nil
+}
+
+// Acquire on Windows returns an error because flock is not available.
+func (l *FlockPushLock) Acquire(ctx context.Context) (func(), error) {
+	return nil, fmt.Errorf("push lock is not supported on Windows")
+}

--- a/pkg/pushlock/pushlock.go
+++ b/pkg/pushlock/pushlock.go
@@ -1,0 +1,110 @@
+// Package pushlock serializes registry push operations across OS processes.
+package pushlock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// PushLock serializes registry push operations across processes.
+// Implementations must be safe for use across OS processes on the same machine.
+type PushLock interface {
+	// Acquire blocks until this process may push.
+	// The returned release function MUST be called when the push completes or fails.
+	// Context cancellation unblocks a waiting Acquire.
+	Acquire(ctx context.Context) (release func(), err error)
+}
+
+// FlockPushLock uses flock(2) advisory locking on a shared file.
+// The lock is automatically released by the kernel if the process dies.
+// The lock file contains metadata about the current holder for diagnostics.
+type FlockPushLock struct {
+	path   string
+	logger *zap.Logger
+}
+
+// NewFlockPushLock creates a PushLock backed by flock on the given path.
+// The path must be absolute.
+func NewFlockPushLock(path string, logger *zap.Logger) (*FlockPushLock, error) {
+	if path == "" {
+		return nil, fmt.Errorf("push lock path must not be empty")
+	}
+	if path[0] != '/' {
+		return nil, fmt.Errorf("push lock path must be absolute, got %q", path)
+	}
+	return &FlockPushLock{path: path, logger: logger}, nil
+}
+
+// Acquire blocks until the flock is obtained. While waiting, it reads
+// the lock file to log who currently holds the lock.
+func (l *FlockPushLock) Acquire(ctx context.Context) (func(), error) {
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("push lock open %s: %w", l.path, err)
+	}
+
+	start := time.Now()
+
+	// Try non-blocking first
+	err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		// Lock is held by another process — log who
+		holder := readHolder(f)
+		l.logger.Info("push lock waiting",
+			zap.String("path", l.path),
+			zap.String("holder", holder),
+		)
+
+		// Block until acquired, checking context in a goroutine
+		acquired := make(chan error, 1)
+		go func() {
+			acquired <- syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+		}()
+
+		select {
+		case err = <-acquired:
+			if err != nil {
+				f.Close()
+				return nil, fmt.Errorf("push lock flock %s: %w", l.path, err)
+			}
+		case <-ctx.Done():
+			f.Close()
+			return nil, ctx.Err()
+		}
+
+		l.logger.Info("push lock acquired",
+			zap.String("path", l.path),
+			zap.Duration("waited", time.Since(start)),
+		)
+	}
+
+	// Write metadata about current holder
+	writeHolder(f)
+
+	release := func() {
+		syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		f.Close()
+	}
+	return release, nil
+}
+
+func writeHolder(f *os.File) {
+	f.Truncate(0)
+	f.Seek(0, 0)
+	fmt.Fprintf(f, "pid=%d\nstarted=%s\n", os.Getpid(), time.Now().Format(time.RFC3339))
+}
+
+func readHolder(f *os.File) string {
+	f.Seek(0, 0)
+	buf := make([]byte, 256)
+	n, _ := f.Read(buf)
+	if n == 0 {
+		return "(unknown)"
+	}
+	return string(buf[:n])
+}

--- a/pkg/pushlock/pushlock.go
+++ b/pkg/pushlock/pushlock.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"syscall"
 	"time"
 
 	"go.uber.org/zap"
@@ -34,63 +33,10 @@ func NewFlockPushLock(path string, logger *zap.Logger) (*FlockPushLock, error) {
 	if path == "" {
 		return nil, fmt.Errorf("push lock path must not be empty")
 	}
-	if path[0] != '/' {
-		return nil, fmt.Errorf("push lock path must be absolute, got %q", path)
+	if err := validateAbsPath(path); err != nil {
+		return nil, err
 	}
 	return &FlockPushLock{path: path, logger: logger}, nil
-}
-
-// Acquire blocks until the flock is obtained. While waiting, it reads
-// the lock file to log who currently holds the lock.
-func (l *FlockPushLock) Acquire(ctx context.Context) (func(), error) {
-	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		return nil, fmt.Errorf("push lock open %s: %w", l.path, err)
-	}
-
-	start := time.Now()
-
-	// Try non-blocking first
-	err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
-	if err != nil {
-		// Lock is held by another process — log who
-		holder := readHolder(f)
-		l.logger.Info("push lock waiting",
-			zap.String("path", l.path),
-			zap.String("holder", holder),
-		)
-
-		// Block until acquired, checking context in a goroutine
-		acquired := make(chan error, 1)
-		go func() {
-			acquired <- syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
-		}()
-
-		select {
-		case err = <-acquired:
-			if err != nil {
-				f.Close()
-				return nil, fmt.Errorf("push lock flock %s: %w", l.path, err)
-			}
-		case <-ctx.Done():
-			f.Close()
-			return nil, ctx.Err()
-		}
-
-		l.logger.Info("push lock acquired",
-			zap.String("path", l.path),
-			zap.Duration("waited", time.Since(start)),
-		)
-	}
-
-	// Write metadata about current holder
-	writeHolder(f)
-
-	release := func() {
-		syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-		f.Close()
-	}
-	return release, nil
 }
 
 func writeHolder(f *os.File) {

--- a/pkg/pushlock/pushlock_test.go
+++ b/pkg/pushlock/pushlock_test.go
@@ -1,0 +1,164 @@
+package pushlock
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestNewFlockPushLock_RejectsRelativePath(t *testing.T) {
+	_, err := NewFlockPushLock("relative/path.lock", zap.NewNop())
+	if err == nil {
+		t.Fatal("expected error for relative path")
+	}
+}
+
+func TestNewFlockPushLock_RejectsEmptyPath(t *testing.T) {
+	_, err := NewFlockPushLock("", zap.NewNop())
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestFlockPushLock_AcquireRelease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.lock")
+	logger := zaptest.NewLogger(t)
+
+	lock, err := NewFlockPushLock(path, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	release, err := lock.Acquire(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Lock file should exist with metadata
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) == 0 {
+		t.Error("lock file should contain holder metadata")
+	}
+
+	release()
+}
+
+func TestFlockPushLock_Serializes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.lock")
+	logger := zaptest.NewLogger(t)
+
+	lock, err := NewFlockPushLock(path, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var concurrent atomic.Int32
+	var maxConcurrent atomic.Int32
+	var wg sync.WaitGroup
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release, err := lock.Acquire(context.Background())
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer release()
+
+			n := concurrent.Add(1)
+			if n > maxConcurrent.Load() {
+				maxConcurrent.Store(n)
+			}
+			// Simulate push work
+			time.Sleep(10 * time.Millisecond)
+			concurrent.Add(-1)
+		}()
+	}
+
+	wg.Wait()
+
+	if maxConcurrent.Load() > 1 {
+		t.Errorf("expected max concurrency 1, got %d", maxConcurrent.Load())
+	}
+}
+
+func TestFlockPushLock_ContextCancellation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.lock")
+	logger := zaptest.NewLogger(t)
+
+	lock, err := NewFlockPushLock(path, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Hold the lock
+	release, err := lock.Acquire(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to acquire with a cancelled context
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err = lock.Acquire(ctx)
+	if err == nil {
+		t.Error("expected error from cancelled context")
+	}
+
+	release()
+}
+
+func TestFlockPushLock_HolderMetadata(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.lock")
+	logger := zaptest.NewLogger(t)
+
+	lock, err := NewFlockPushLock(path, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	release, err := lock.Acquire(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !contains(content, "pid=") {
+		t.Errorf("expected pid in metadata, got %q", content)
+	}
+	if !contains(content, "started=") {
+		t.Errorf("expected started in metadata, got %q", content)
+	}
+
+	release()
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/pushlock/pushlock_test.go
+++ b/pkg/pushlock/pushlock_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package pushlock
 
 import (

--- a/scripts/publish.go
+++ b/scripts/publish.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	publishVersion    = "0.7.8"
+	publishVersion    = "0.7.9"
 	releaseBinaryName = regexp.MustCompile(`^contain-v(?P<version>\d+\.\d+\.\d+)-(?P<os>[a-z0-9]+)-(?P<arch>[a-z0-9]+)(?P<ext>\.exe)?(?P<checksum>\.[a-z0-9]+)?$`)
 )
 

--- a/test.sh
+++ b/test.sh
@@ -7,6 +7,12 @@ set -eo pipefail
 
 go test ./pkg/...
 
+# test-k8s.sh creates a k3d cluster; fail early if one already exists
+if command -v k3d >/dev/null 2>&1 && k3d cluster list 2>/dev/null | grep -q "^turbokube-test-contain "; then
+  echo "ERROR: k3d cluster 'turbokube-test-contain' already exists. Delete it first: k3d cluster delete turbokube-test-contain"
+  exit 1
+fi
+
 command -v container-structure-test >/dev/null 2>&1 || {
   echo "container-structure-test not found. Install it or use y-container-structure-test from ystack."
   exit 1


### PR DESCRIPTION
Concurrent pushes (for example from turborepo workflows) cause two problems:
- resource spikes for the registry and possible 499 statuses
- suboptimal reuse of shared/base layers

Can now be blocked to 1 push using env CONTAIN_PUSH_LOCK_PATH or flag --push-lock. Env is recommended as this feature is only meaningful when it's configured for multiple processes. The flag can be used to opt out.