### PR TITLE
Per-arch localFile source via pathPerPlatform

### DIFF
--- a/cmd/contain/build.go
+++ b/cmd/contain/build.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 	"time"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/spf13/cobra"
 	"github.com/turbokube/contain/pkg/appender"
 	"github.com/turbokube/contain/pkg/contain"
 	containenv "github.com/turbokube/contain/pkg/env"
+	"github.com/turbokube/contain/pkg/layers"
 	"github.com/turbokube/contain/pkg/pushed"
 	"github.com/turbokube/contain/pkg/pushlock"
 	"github.com/turbokube/contain/pkg/sbom"
@@ -49,6 +51,25 @@ func newBuildCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "build [context path]",
 		Short: "Build/append layers into an image",
+		Long: `Build/append layers into an image.
+
+Per-architecture source files for multi-arch images
+---------------------------------------------------
+A localFile layer can declare a different source path per platform, for
+example when each arch variant of the image should contain a natively
+built binary:
+
+  layers:
+  - localFile:
+      path: target/linux/amd64/mybinary        # fallback
+      pathPerPlatform:
+        linux/amd64: target/linux/amd64/mybinary
+        linux/arm64: target/linux/arm64/mybinary
+      containerPath: /usr/local/bin/mybinary
+
+For every platform present in the base image index, contain first looks
+up pathPerPlatform[<os>/<arch>]; if that is absent it falls back to
+path. If neither resolves, the build fails before any push.`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 1 {
 				return errors.New("too many args: at most one context path")
@@ -190,7 +211,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	}
 	zap.L().Info("config", aboutConfig...)
 
-	layers, err := contain.RunLayers(config)
+	builders, err := contain.RunLayers(config)
 	if err != nil {
 		zap.L().Fatal("layers", zap.Error(err))
 	}
@@ -204,7 +225,14 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			zap.L().Fatal("containersync init", zap.Error(err))
 		}
-		target, err := sync.Run(layers...)
+		// Sync is targeted at one running pod; per-platform resolution is not
+		// meaningful here. localDir and localFile-with-Path work unchanged;
+		// localFile.pathPerPlatform is effectively unsupported for -r.
+		syncLayers, err := layers.Build(builders, v1.Platform{})
+		if err != nil {
+			zap.L().Fatal("layers build", zap.Error(err))
+		}
+		target, err := sync.Run(syncLayers...)
 		if err != nil {
 			zap.L().Fatal("containersync run", zap.Error(err))
 		}
@@ -289,7 +317,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	buildOutput, err := contain.RunAppend(config, layers, contain.WriteOptions{
+	buildOutput, err := contain.RunAppend(config, builders, contain.WriteOptions{
 		Push:         pushFlag,
 		OutputPath:   effectiveOutput,
 		OutputFormat: effectiveFormat,

--- a/jsonschema/config.json
+++ b/jsonschema/config.json
@@ -126,6 +126,12 @@
         "path": {
           "type": "string"
         },
+        "pathPerPlatform": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
         "containerPath": {
           "type": "string"
         },
@@ -134,10 +140,7 @@
         }
       },
       "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "path"
-      ]
+      "type": "object"
     }
   }
 }

--- a/pkg/contain/libcontain.go
+++ b/pkg/contain/libcontain.go
@@ -39,11 +39,11 @@ func Run(config schemav1.ContainConfig) (*pushed.Artifact, error) {
 	// if err != nil {
 	// 	return nil, err
 	// }
-	layers, err := RunLayers(config)
+	builders, err := RunLayers(config)
 	if err != nil {
 		return nil, err
 	}
-	output, err := RunAppend(config, layers, WriteOptions{Push: true})
+	output, err := RunAppend(config, builders, WriteOptions{Push: true})
 	if err != nil {
 		return nil, err
 	}
@@ -53,8 +53,13 @@ func Run(config schemav1.ContainConfig) (*pushed.Artifact, error) {
 	return nil, fmt.Errorf("no build output available")
 }
 
-// RunLayers is the file system access part of a run
-func RunLayers(config schemav1.ContainConfig) ([]v1.Layer, error) {
+// RunLayers is the file system access part of a run.
+// The returned builders are invoked per-platform inside RunAppend, once
+// the base index has been fetched and the set of target platforms is
+// known. For platform-agnostic layers (localDir, or localFile with only
+// Path set) the builder ignores its argument; for
+// localFile.pathPerPlatform the builder resolves the source per call.
+func RunLayers(config schemav1.ContainConfig) ([]layers.LayerBuilder, error) {
 
 	layerBuilders := make([]layers.LayerBuilder, len(config.Layers))
 	for i, layerCfg := range config.Layers {
@@ -70,24 +75,14 @@ func RunLayers(config schemav1.ContainConfig) ([]v1.Layer, error) {
 		layerBuilders[i] = b
 	}
 
-	layers := make([]v1.Layer, len(layerBuilders))
-	for i, builder := range layerBuilders {
-		layer, err := builder()
-		if err != nil {
-			zap.L().Error("layer builder invocation failed", zap.Error(err))
-			return nil, err
-		}
-		layers[i] = layer
-	}
-
-	return layers, nil
+	return layerBuilders, nil
 
 }
 
 // Removed NewPushedSingleImage: producers now return *pushed.Artifact directly.
 
 // RunAppend is the remote access part of a run
-func RunAppend(config schemav1.ContainConfig, layers []v1.Layer, opts WriteOptions) (*pushed.BuildOutput, error) {
+func RunAppend(config schemav1.ContainConfig, builders []layers.LayerBuilder, opts WriteOptions) (*pushed.BuildOutput, error) {
 	// source repo can differ from destination repo, we should probably struct tag + remote config
 	var baseRegistry *registry.RegistryConfig
 	var tagRegistry *registry.RegistryConfig
@@ -115,7 +110,36 @@ func RunAppend(config schemav1.ContainConfig, layers []v1.Layer, opts WriteOptio
 		return nil, err
 	}
 
-	each := func(b name.Digest, t name.Reference, tr *registry.RegistryConfig, _ v1.Platform) (mutate.IndexAddendum, error) {
+	// Collect the set of platforms we will push to. In the single-platform
+	// code path below we still need a platform to invoke the builders, so
+	// pull that from the prototype.
+	var targetPlatforms []v1.Platform
+	if index.SizeAppend() > 1 {
+		targetPlatforms = index.MatchedPlatforms()
+	} else {
+		targetPlatforms = []v1.Platform{index.PrototypePlatform()}
+	}
+
+	// Fail fast before any push if the config shape is broken or if any
+	// platform in the base index has no resolvable localFile source.
+	if err := schemav1.ValidateLayers(config, targetPlatforms); err != nil {
+		zap.L().Error("layers validate", zap.Error(err))
+		return nil, err
+	}
+
+	// Pre-build all layers for all target platforms before any push, so a
+	// filesystem error on one platform does not leave others half-pushed.
+	layersByPlatform := make(map[string][]v1.Layer, len(targetPlatforms))
+	for _, p := range targetPlatforms {
+		built, err := layers.Build(builders, p)
+		if err != nil {
+			zap.L().Error("layer builder invocation failed", zap.String("platform", p.String()), zap.Error(err))
+			return nil, err
+		}
+		layersByPlatform[p.String()] = built
+	}
+
+	each := func(b name.Digest, t name.Reference, tr *registry.RegistryConfig, platform v1.Platform) (mutate.IndexAddendum, error) {
 		a, err := appender.New(b, tr, t)
 		if err != nil {
 			zap.L().Error("appender", zap.Error(err))
@@ -147,7 +171,7 @@ func RunAppend(config schemav1.ContainConfig, layers []v1.Layer, opts WriteOptio
 		} else {
 			zap.L().Error("base image annotations", zap.Error(err))
 		}
-		r, err := a.Append(layers...)
+		r, err := a.Append(layersByPlatform[platform.String()]...)
 		if err != nil {
 			zap.L().Error("append", zap.Error(err))
 			return mutate.IndexAddendum{}, err

--- a/pkg/contain/pathperplatform_test.go
+++ b/pkg/contain/pathperplatform_test.go
@@ -1,0 +1,203 @@
+package contain_test
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	. "github.com/onsi/gomega"
+	"github.com/turbokube/contain/pkg/appender"
+	"github.com/turbokube/contain/pkg/contain"
+	schema "github.com/turbokube/contain/pkg/schema/v1"
+	"github.com/turbokube/contain/pkg/testcases"
+)
+
+// baseimage-multiarch1:noattest is a two-platform index: linux/amd64 and
+// linux/arm64. That makes it a realistic stand-in for a distroless static
+// base when exercising per-arch path resolution.
+const pathPerPlatformBase = "contain-test/baseimage-multiarch1:noattest@sha256:f9f2106a04a339d282f1152f0be7c9ce921a0c01320de838cda364948de66bd4"
+
+// fileInPlatformManifest pulls the arch-specific manifest from an index,
+// extracts its single appended layer, and returns the tar body at
+// containerPath. Fails the test if containerPath is not present.
+func fileInPlatformManifest(t *testing.T, indexRef string, platform v1.Platform, containerPath string) string {
+	t.Helper()
+	digest, err := crane.Digest(indexRef, crane.WithPlatform(&platform), crane.WithAuthFromKeychain(nil), crane.WithAuth(nil))
+	Expect(err).NotTo(HaveOccurred())
+
+	// Parse reference of the arch manifest (index@digest).
+	withDigest := strings.SplitN(indexRef, "@", 2)[0] + "@" + digest
+	img, err := crane.Pull(withDigest, crane.WithPlatform(&platform), crane.WithAuth(nil))
+	Expect(err).NotTo(HaveOccurred())
+
+	rc := mutate.Extract(img)
+	defer rc.Close()
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar: %v", err)
+		}
+		if hdr.Name == containerPath {
+			buf := new(strings.Builder)
+			if _, err := io.Copy(buf, tr); err != nil {
+				t.Fatalf("copy: %v", err)
+			}
+			return buf.String()
+		}
+	}
+	t.Fatalf("%s not found in %s for %s", containerPath, indexRef, platform.String())
+	return ""
+}
+
+// writeFile writes body to dir/name and returns the absolute path, for use
+// with RunConfig's TempDir.
+func writeTestFile(t *testing.T, dir *testcases.TempDir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir.Root(), name)
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return name
+}
+
+func TestPathPerPlatform_DifferentBytesPerArch(t *testing.T) {
+	RegisterTestingT(t)
+	dir := testcases.NewTempDir(t)
+	amdName := writeTestFile(t, dir, "amd64.bin", "AMD64-BODY")
+	armName := writeTestFile(t, dir, "arm64.bin", "ARM64-BODY")
+
+	cfg := schema.ContainConfig{
+		Base: pathPerPlatformBase,
+		Tag:  "contain-test/pathperplatform:distinct",
+		Platforms: []string{"linux/amd64", "linux/arm64"},
+		Layers: []schema.Layer{{
+			LocalFile: schema.LocalFile{
+				PathPerPlatform: map[string]string{
+					"linux/amd64": amdName,
+					"linux/arm64": armName,
+				},
+				ContainerPath: "/usr/local/bin/mybinary",
+			},
+		}},
+	}
+	cfg.Base = fmt.Sprintf("%s/%s", testRegistry, cfg.Base)
+	cfg.Tag = fmt.Sprintf("%s/%s", testRegistry, cfg.Tag)
+
+	chdir := appender.NewChdir(dir.Root())
+	defer chdir.Cleanup()
+
+	builders, err := contain.RunLayers(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	out, err := contain.RunAppend(cfg, builders, contain.WriteOptions{Push: true})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(out).NotTo(BeNil())
+
+	artifact := out.Artifact()
+	ref := artifact.Reference()
+	amdBody := fileInPlatformManifest(t, ref.String(), v1.Platform{OS: "linux", Architecture: "amd64"}, "/usr/local/bin/mybinary")
+	armBody := fileInPlatformManifest(t, ref.String(), v1.Platform{OS: "linux", Architecture: "arm64"}, "/usr/local/bin/mybinary")
+
+	Expect(amdBody).To(Equal("AMD64-BODY"))
+	Expect(armBody).To(Equal("ARM64-BODY"))
+
+	// The per-arch layer digests must differ.
+	amdImg, err := remote.Image(ref, append(testCraneOptions.Remote, remote.WithPlatform(v1.Platform{OS: "linux", Architecture: "amd64"}))...)
+	Expect(err).NotTo(HaveOccurred())
+	armImg, err := remote.Image(ref, append(testCraneOptions.Remote, remote.WithPlatform(v1.Platform{OS: "linux", Architecture: "arm64"}))...)
+	Expect(err).NotTo(HaveOccurred())
+
+	amdDigest, err := amdImg.Digest()
+	Expect(err).NotTo(HaveOccurred())
+	armDigest, err := armImg.Digest()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(amdDigest).NotTo(Equal(armDigest), "per-arch manifests must differ")
+}
+
+func TestPathPerPlatform_FallbackPathCoversUnlistedArch(t *testing.T) {
+	RegisterTestingT(t)
+	dir := testcases.NewTempDir(t)
+	writeTestFile(t, dir, "amd64.bin", "AMD64-BODY")
+	writeTestFile(t, dir, "fallback.bin", "FALLBACK-BODY")
+
+	cfg := schema.ContainConfig{
+		Base: pathPerPlatformBase,
+		Tag:  "contain-test/pathperplatform:fallback",
+		Platforms: []string{"linux/amd64", "linux/arm64"},
+		Layers: []schema.Layer{{
+			LocalFile: schema.LocalFile{
+				Path: "fallback.bin",
+				PathPerPlatform: map[string]string{
+					"linux/amd64": "amd64.bin",
+				},
+				ContainerPath: "/usr/local/bin/mybinary",
+			},
+		}},
+	}
+	cfg.Base = fmt.Sprintf("%s/%s", testRegistry, cfg.Base)
+	cfg.Tag = fmt.Sprintf("%s/%s", testRegistry, cfg.Tag)
+
+	chdir := appender.NewChdir(dir.Root())
+	defer chdir.Cleanup()
+
+	builders, err := contain.RunLayers(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	out, err := contain.RunAppend(cfg, builders, contain.WriteOptions{Push: true})
+	Expect(err).NotTo(HaveOccurred())
+
+	artifact := out.Artifact()
+	ref := artifact.Reference().String()
+	amdBody := fileInPlatformManifest(t, ref, v1.Platform{OS: "linux", Architecture: "amd64"}, "/usr/local/bin/mybinary")
+	armBody := fileInPlatformManifest(t, ref, v1.Platform{OS: "linux", Architecture: "arm64"}, "/usr/local/bin/mybinary")
+
+	Expect(amdBody).To(Equal("AMD64-BODY"))
+	Expect(armBody).To(Equal("FALLBACK-BODY"))
+}
+
+func TestPathPerPlatform_MissingPlatformErrorsBeforeAnyPush(t *testing.T) {
+	RegisterTestingT(t)
+	dir := testcases.NewTempDir(t)
+	writeTestFile(t, dir, "amd64.bin", "AMD64-BODY")
+
+	const tag = "contain-test/pathperplatform:missing"
+	cfg := schema.ContainConfig{
+		Base:      pathPerPlatformBase,
+		Tag:       tag,
+		Platforms: []string{"linux/amd64", "linux/arm64"},
+		Layers: []schema.Layer{{
+			LocalFile: schema.LocalFile{
+				PathPerPlatform: map[string]string{
+					"linux/amd64": "amd64.bin",
+				},
+				ContainerPath: "/usr/local/bin/mybinary",
+			},
+		}},
+	}
+	cfg.Base = fmt.Sprintf("%s/%s", testRegistry, cfg.Base)
+	cfg.Tag = fmt.Sprintf("%s/%s", testRegistry, cfg.Tag)
+
+	chdir := appender.NewChdir(dir.Root())
+	defer chdir.Cleanup()
+
+	builders, err := contain.RunLayers(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = contain.RunAppend(cfg, builders, contain.WriteOptions{Push: true})
+	Expect(err).To(HaveOccurred(), "expected missing-platform error")
+	Expect(err.Error()).To(ContainSubstring("linux/arm64"), "error should name the missing platform")
+	Expect(err.Error()).To(ContainSubstring("pathPerPlatform"), "error should suggest the fix")
+
+	// No manifest should have been pushed under the target tag.
+	_, headErr := crane.Head(cfg.Tag, crane.WithAuth(nil))
+	Expect(headErr).To(HaveOccurred(), "tag must not exist after a failed validation")
+}

--- a/pkg/layers/layers.go
+++ b/pkg/layers/layers.go
@@ -10,25 +10,62 @@ import (
 	schema "github.com/turbokube/contain/pkg/schema/v1"
 )
 
-type LayerBuilder func() (v1.Layer, error)
+// LayerBuilder produces a layer for the given platform. Builders for
+// platform-agnostic layers (localDir, localFile with only Path set) ignore
+// the argument; builders for localFile.pathPerPlatform resolve the source
+// path per call.
+type LayerBuilder func(platform v1.Platform) (v1.Layer, error)
+
+// Build invokes every builder for platform and returns the resulting
+// layer slice. Callers that do not need per-platform resolution (for
+// example sync to a running container) may pass the zero v1.Platform;
+// that works for localDir and for localFile configs that only set Path.
+func Build(builders []LayerBuilder, platform v1.Platform) ([]v1.Layer, error) {
+	out := make([]v1.Layer, len(builders))
+	for i, b := range builders {
+		layer, err := b(platform)
+		if err != nil {
+			return nil, fmt.Errorf("layer %d for %s: %w", i, platform.String(), err)
+		}
+		out[i] = layer
+	}
+	return out, nil
+}
 
 func NewLayerBuilder(cfg schema.Layer) (LayerBuilder, error) {
-	// TODO can we check that only one option is set
-	// (this concept is modelled on skaffold's "build:" config)
-	if cfg.LocalFile.Path != "" {
+	hasLocalFile := cfg.LocalFile.Path != "" || len(cfg.LocalFile.PathPerPlatform) > 0
+	if hasLocalFile {
 		if cfg.LocalDir.Path != "" {
 			return nil, errors.New("each layer item must have exactly one type, got localFile and localDir")
 		}
-		return configure(localdir.NewFile(), schema.LocalDir{
-			Path:          cfg.LocalFile.Path,
-			ContainerPath: cfg.LocalFile.ContainerPath,
-			MaxSize:       cfg.LocalFile.MaxSize,
-		}, cfg.Attributes)
+		return newLocalFileBuilder(cfg.LocalFile, cfg.Attributes)
 	}
 	if cfg.LocalDir.Path != "" {
 		return configure(localdir.NewDir(), cfg.LocalDir, cfg.Attributes)
 	}
 	return nil, errors.New("no layer builder config found")
+}
+
+// newLocalFileBuilder returns a builder that resolves the source path for
+// the requested platform on each invocation. This is the per-arch
+// localFile path; for localFile configs with only Path set the closure
+// still works (ResolveLocalFilePath returns Path regardless of platform).
+func newLocalFileBuilder(lf schema.LocalFile, attributes schema.LayerAttributes) (LayerBuilder, error) {
+	return func(platform v1.Platform) (v1.Layer, error) {
+		resolved := schema.ResolveLocalFilePath(lf, platform)
+		if resolved == "" {
+			return nil, fmt.Errorf("localFile: no path for platform %s", platform.String())
+		}
+		inner, err := configure(localdir.NewFile(), schema.LocalDir{
+			Path:          resolved,
+			ContainerPath: lf.ContainerPath,
+			MaxSize:       lf.MaxSize,
+		}, attributes)
+		if err != nil {
+			return nil, err
+		}
+		return inner(platform)
+	}, nil
 }
 
 func configure(dir localdir.From, cfg schema.LocalDir, attributes schema.LayerAttributes) (LayerBuilder, error) {
@@ -53,7 +90,7 @@ func configure(dir localdir.From, cfg schema.LocalDir, attributes schema.LayerAt
 		}
 		dir.MaxSize = s
 	}
-	return func() (v1.Layer, error) {
+	return func(_ v1.Platform) (v1.Layer, error) {
 		return localdir.FromFilesystem(dir, attributes)
 	}, nil
 }

--- a/pkg/layers/layers_test.go
+++ b/pkg/layers/layers_test.go
@@ -1,0 +1,228 @@
+package layers
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	schema "github.com/turbokube/contain/pkg/schema/v1"
+)
+
+// layerFiles returns a name->contents map extracted from the layer's
+// uncompressed tar stream. Used to assert the file content produced for
+// each platform.
+func layerFiles(t *testing.T, layer v1.Layer) map[string]string {
+	t.Helper()
+	rc, err := layer.Uncompressed()
+	if err != nil {
+		t.Fatalf("uncompressed: %v", err)
+	}
+	defer rc.Close()
+	out := map[string]string{}
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar read: %v", err)
+		}
+		buf := new(strings.Builder)
+		if _, err := io.Copy(buf, tr); err != nil {
+			t.Fatalf("tar copy: %v", err)
+		}
+		out[hdr.Name] = buf.String()
+	}
+	return out
+}
+
+func writeFile(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+func amd64() v1.Platform { return v1.Platform{OS: "linux", Architecture: "amd64"} }
+func arm64() v1.Platform { return v1.Platform{OS: "linux", Architecture: "arm64"} }
+
+func TestNewLayerBuilder_LocalFilePathPerPlatform(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "amd64.bin", "AMD")
+	writeFile(t, dir, "arm64.bin", "ARM")
+
+	cfg := schema.Layer{LocalFile: schema.LocalFile{
+		PathPerPlatform: map[string]string{
+			"linux/amd64": filepath.Join(dir, "amd64.bin"),
+			"linux/arm64": filepath.Join(dir, "arm64.bin"),
+		},
+		ContainerPath: "/bin/mybinary",
+	}}
+	b, err := NewLayerBuilder(cfg)
+	if err != nil {
+		t.Fatalf("NewLayerBuilder: %v", err)
+	}
+
+	amdLayer, err := b(amd64())
+	if err != nil {
+		t.Fatalf("amd64 build: %v", err)
+	}
+	armLayer, err := b(arm64())
+	if err != nil {
+		t.Fatalf("arm64 build: %v", err)
+	}
+
+	amdFiles := layerFiles(t, amdLayer)
+	armFiles := layerFiles(t, armLayer)
+	if got := amdFiles["/bin/mybinary"]; got != "AMD" {
+		t.Errorf("amd64 file got %q, want AMD (files: %v)", got, amdFiles)
+	}
+	if got := armFiles["/bin/mybinary"]; got != "ARM" {
+		t.Errorf("arm64 file got %q, want ARM (files: %v)", got, armFiles)
+	}
+
+	amdDigest, _ := amdLayer.Digest()
+	armDigest, _ := armLayer.Digest()
+	if amdDigest == armDigest {
+		t.Errorf("per-arch layers must have distinct digests, both %s", amdDigest)
+	}
+}
+
+func TestNewLayerBuilder_FallbackPathUsedWhenPlatformMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "fallback.bin", "FALLBACK")
+	writeFile(t, dir, "amd64.bin", "AMD")
+
+	cfg := schema.Layer{LocalFile: schema.LocalFile{
+		Path: filepath.Join(dir, "fallback.bin"),
+		PathPerPlatform: map[string]string{
+			"linux/amd64": filepath.Join(dir, "amd64.bin"),
+		},
+		ContainerPath: "/bin/x",
+	}}
+	b, err := NewLayerBuilder(cfg)
+	if err != nil {
+		t.Fatalf("NewLayerBuilder: %v", err)
+	}
+	armLayer, err := b(arm64())
+	if err != nil {
+		t.Fatalf("arm64 build: %v", err)
+	}
+	files := layerFiles(t, armLayer)
+	if got := files["/bin/x"]; got != "FALLBACK" {
+		t.Errorf("arm64 should use fallback path, got %q (files: %v)", got, files)
+	}
+}
+
+func TestNewLayerBuilder_ErrorWhenNoPathResolvesForPlatform(t *testing.T) {
+	cfg := schema.Layer{LocalFile: schema.LocalFile{
+		PathPerPlatform: map[string]string{"linux/amd64": "unused"},
+	}}
+	b, err := NewLayerBuilder(cfg)
+	if err != nil {
+		t.Fatalf("NewLayerBuilder: %v", err)
+	}
+	if _, err := b(arm64()); err == nil {
+		t.Fatal("expected error for arm64 with no matching path")
+	} else if !strings.Contains(err.Error(), "linux/arm64") {
+		t.Errorf("error should name platform, got %v", err)
+	}
+}
+
+func TestNewLayerBuilder_LocalDirIgnoresPlatform(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.txt", "A")
+
+	cfg := schema.Layer{LocalDir: schema.LocalDir{Path: dir, ContainerPath: "/app"}}
+	b, err := NewLayerBuilder(cfg)
+	if err != nil {
+		t.Fatalf("NewLayerBuilder: %v", err)
+	}
+	amdLayer, err := b(amd64())
+	if err != nil {
+		t.Fatalf("amd64 build: %v", err)
+	}
+	armLayer, err := b(arm64())
+	if err != nil {
+		t.Fatalf("arm64 build: %v", err)
+	}
+	amdDigest, _ := amdLayer.Digest()
+	armDigest, _ := armLayer.Digest()
+	if amdDigest != armDigest {
+		t.Errorf("localDir should produce identical layer across platforms, got %s vs %s", amdDigest, armDigest)
+	}
+}
+
+func TestNewLayerBuilder_RejectsBothLocalFileAndLocalDir(t *testing.T) {
+	cfg := schema.Layer{
+		LocalFile: schema.LocalFile{Path: "a"},
+		LocalDir:  schema.LocalDir{Path: "b"},
+	}
+	_, err := NewLayerBuilder(cfg)
+	if err == nil || !strings.Contains(err.Error(), "exactly one type") {
+		t.Errorf("expected 'exactly one type' error, got %v", err)
+	}
+}
+
+func TestNewLayerBuilder_RejectsEmptyConfig(t *testing.T) {
+	_, err := NewLayerBuilder(schema.Layer{})
+	if err == nil || !strings.Contains(err.Error(), "no layer builder config found") {
+		t.Errorf("expected 'no layer builder config found' error, got %v", err)
+	}
+}
+
+func TestNewLayerBuilder_LocalFilePropagatesConfigureError(t *testing.T) {
+	// Invalid MaxSize surfaces an error from configure() and should bubble
+	// up through the per-platform closure rather than panic.
+	cfg := schema.Layer{LocalFile: schema.LocalFile{
+		Path:    "/dev/null",
+		MaxSize: "not-a-size",
+	}}
+	b, err := NewLayerBuilder(cfg)
+	if err != nil {
+		t.Fatalf("NewLayerBuilder: %v", err)
+	}
+	if _, err := b(amd64()); err == nil {
+		t.Fatal("expected error from invalid MaxSize")
+	}
+}
+
+func TestBuild_InvokesAllBuildersWithPlatform(t *testing.T) {
+	var gotPlatforms []v1.Platform
+	stub := func(p v1.Platform) (v1.Layer, error) {
+		gotPlatforms = append(gotPlatforms, p)
+		return nil, nil
+	}
+	_, err := Build([]LayerBuilder{stub, stub}, amd64())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(gotPlatforms) != 2 {
+		t.Fatalf("expected two invocations, got %d", len(gotPlatforms))
+	}
+	for i, p := range gotPlatforms {
+		if p.OS != "linux" || p.Architecture != "amd64" {
+			t.Errorf("invocation %d: expected linux/amd64, got %s", i, p.String())
+		}
+	}
+}
+
+func TestBuild_WrapsErrorWithIndexAndPlatform(t *testing.T) {
+	stub := func(p v1.Platform) (v1.Layer, error) {
+		return nil, io.EOF
+	}
+	_, err := Build([]LayerBuilder{stub}, arm64())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "layer 0") || !strings.Contains(err.Error(), "linux/arm64") {
+		t.Errorf("error should include index and platform, got %q", err.Error())
+	}
+}

--- a/pkg/multiarch/index.go
+++ b/pkg/multiarch/index.go
@@ -230,6 +230,17 @@ func (m *IndexManifests) PrototypePlatform() v1.Platform {
 	return *m.prototype.meta.Platform
 }
 
+// MatchedPlatforms returns the platforms of every manifest we plan to append
+// to, in the order they appear in the base index. Used to validate
+// per-platform configuration before any push.
+func (m *IndexManifests) MatchedPlatforms() []v1.Platform {
+	out := make([]v1.Platform, len(m.toAppend))
+	for i, c := range m.toAppend {
+		out[i] = *c.meta.Platform
+	}
+	return out
+}
+
 // SizeAppend is the number of manifests we'd append to
 // in constrast to for example SizeBase = original size, SizeResult = in the index that will be pushed
 func (m *IndexManifests) SizeAppend() int {

--- a/pkg/schema/jsonschema_test.go
+++ b/pkg/schema/jsonschema_test.go
@@ -31,5 +31,21 @@ func TestJsonschema(t *testing.T) {
 		n, err := f.Write(data)
 		Expect(err).To(BeNil())
 		Expect(n > 0).To(BeTrue())
+
+		// Guardrails on the LocalFile schema shape: pathPerPlatform is an
+		// object with string values, and neither path nor pathPerPlatform
+		// is individually required (either satisfies the config — enforced
+		// at runtime by ValidateLayers, not by the JSON schema).
+		var doc map[string]interface{}
+		Expect(json.Unmarshal(data, &doc)).To(Succeed())
+		defs := doc["$defs"].(map[string]interface{})
+		localFile := defs["LocalFile"].(map[string]interface{})
+		props := localFile["properties"].(map[string]interface{})
+		ppp, ok := props["pathPerPlatform"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "LocalFile must declare a pathPerPlatform property")
+		Expect(ppp["type"]).To(Equal("object"))
+		Expect(ppp["additionalProperties"]).To(HaveKeyWithValue("type", "string"))
+		_, hasRequired := localFile["required"]
+		Expect(hasRequired).To(BeFalse(), "LocalFile must not hard-require path; either path or pathPerPlatform is accepted")
 	})
 }

--- a/pkg/schema/v1/config.go
+++ b/pkg/schema/v1/config.go
@@ -66,11 +66,18 @@ type LayerAttributes struct {
 }
 
 // LocalFile is a single file that should be appended as-is to base
-// with an optional path prefix, for example ./target/runner to /runner
+// with an optional path prefix, for example ./target/runner to /runner.
+//
+// For multi-arch builds where each platform variant of the image should
+// contain a platform-specific binary, set PathPerPlatform keyed by
+// "<os>/<arch>" (for example "linux/amd64"). Path remains the fallback
+// for platforms not listed in PathPerPlatform. Either Path or at least
+// one PathPerPlatform entry must be set.
 type LocalFile struct {
-	Path          string `json:"path" skaffold:"filepath,template"`
-	ContainerPath string `json:"containerPath,omitempty" skaffold:"template"`
-	MaxSize       string `json:"maxSize,omitempty" skaffold:"template"`
+	Path            string            `json:"path,omitempty" skaffold:"filepath,template"`
+	PathPerPlatform map[string]string `json:"pathPerPlatform,omitempty"`
+	ContainerPath   string            `json:"containerPath,omitempty" skaffold:"template"`
+	MaxSize         string            `json:"maxSize,omitempty" skaffold:"template"`
 }
 
 // LocalDir is a directory structure that should be appended as-is to base

--- a/pkg/schema/v1/localfile.go
+++ b/pkg/schema/v1/localfile.go
@@ -1,0 +1,93 @@
+package v1
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// ResolveLocalFilePath returns the source path to use for this platform.
+// An empty return value means neither PathPerPlatform nor Path is set for
+// this platform; callers must treat that as an error.
+//
+// Matching order:
+//  1. PathPerPlatform[<os>/<arch>/<variant>] (exact, when variant is present)
+//  2. PathPerPlatform[<os>/<arch>] (drop variant/os.version)
+//  3. Path (fallback)
+func ResolveLocalFilePath(lf LocalFile, platform v1.Platform) string {
+	if len(lf.PathPerPlatform) > 0 {
+		if platform.Variant != "" {
+			if p := lf.PathPerPlatform[platform.OS+"/"+platform.Architecture+"/"+platform.Variant]; p != "" {
+				return p
+			}
+		}
+		if p := lf.PathPerPlatform[platform.OS+"/"+platform.Architecture]; p != "" {
+			return p
+		}
+	}
+	return lf.Path
+}
+
+// ValidateLayers checks that every layer has a resolvable source for every
+// platform in platforms. Returns a nil error if everything resolves, or an
+// error naming each offending layer and platform. The error is suitable
+// for early-exit before any registry push.
+func ValidateLayers(config ContainConfig, platforms []v1.Platform) error {
+	var errs []string
+	for i, layer := range config.Layers {
+		hasLocalFile := layer.LocalFile.Path != "" || len(layer.LocalFile.PathPerPlatform) > 0
+		hasLocalDir := layer.LocalDir.Path != ""
+		if hasLocalFile && hasLocalDir {
+			errs = append(errs, fmt.Sprintf("layers[%d]: each layer item must have exactly one type, got localFile and localDir", i))
+			continue
+		}
+		if !hasLocalFile && !hasLocalDir {
+			errs = append(errs, fmt.Sprintf("layers[%d]: no layer builder config found (set localFile.path, localFile.pathPerPlatform, or localDir.path)", i))
+			continue
+		}
+		if !hasLocalFile {
+			continue
+		}
+		keys := make([]string, 0, len(layer.LocalFile.PathPerPlatform))
+		for k := range layer.LocalFile.PathPerPlatform {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if !isValidPlatformKey(key) {
+				errs = append(errs, fmt.Sprintf(`layers[%d].localFile.pathPerPlatform: invalid key %q (expected "<os>/<arch>" or "<os>/<arch>/<variant>")`, i, key))
+			}
+		}
+		for _, p := range platforms {
+			if ResolveLocalFilePath(layer.LocalFile, p) == "" {
+				errs = append(errs, fmt.Sprintf(`layers[%d].localFile: no path for platform %s (add pathPerPlatform[%q] or a top-level path fallback)`, i, p.String(), p.OS+"/"+p.Architecture))
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// isValidPlatformKey accepts "<os>/<arch>" and "<os>/<arch>/<variant>"
+// with non-empty segments. Looser forms (single segment, trailing slash,
+// whitespace) are rejected.
+func isValidPlatformKey(key string) bool {
+	if strings.ContainsAny(key, " \t\n") {
+		return false
+	}
+	parts := strings.Split(key, "/")
+	if len(parts) != 2 && len(parts) != 3 {
+		return false
+	}
+	for _, p := range parts {
+		if p == "" {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/schema/v1/localfile_test.go
+++ b/pkg/schema/v1/localfile_test.go
@@ -1,0 +1,222 @@
+package v1
+
+import (
+	"strings"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func amd64() v1.Platform { return v1.Platform{OS: "linux", Architecture: "amd64"} }
+func arm64() v1.Platform { return v1.Platform{OS: "linux", Architecture: "arm64"} }
+func arm64v8() v1.Platform {
+	return v1.Platform{OS: "linux", Architecture: "arm64", Variant: "v8"}
+}
+
+func TestResolveLocalFilePath_ExactMatch(t *testing.T) {
+	lf := LocalFile{
+		Path: "fallback",
+		PathPerPlatform: map[string]string{
+			"linux/amd64": "amd64-bin",
+			"linux/arm64": "arm64-bin",
+		},
+	}
+	if got := ResolveLocalFilePath(lf, amd64()); got != "amd64-bin" {
+		t.Errorf("amd64 got %q want amd64-bin", got)
+	}
+	if got := ResolveLocalFilePath(lf, arm64()); got != "arm64-bin" {
+		t.Errorf("arm64 got %q want arm64-bin", got)
+	}
+}
+
+func TestResolveLocalFilePath_VariantDroppedToOsArch(t *testing.T) {
+	lf := LocalFile{
+		PathPerPlatform: map[string]string{
+			"linux/arm64": "arm64-bin",
+		},
+	}
+	if got := ResolveLocalFilePath(lf, arm64v8()); got != "arm64-bin" {
+		t.Errorf("variant fallback to os/arch got %q want arm64-bin", got)
+	}
+}
+
+func TestResolveLocalFilePath_ExactVariantPreferredOverOsArch(t *testing.T) {
+	lf := LocalFile{
+		PathPerPlatform: map[string]string{
+			"linux/arm64":    "arm64-generic",
+			"linux/arm64/v8": "arm64-v8",
+		},
+	}
+	if got := ResolveLocalFilePath(lf, arm64v8()); got != "arm64-v8" {
+		t.Errorf("exact variant got %q want arm64-v8", got)
+	}
+}
+
+func TestResolveLocalFilePath_FallbackToPath(t *testing.T) {
+	lf := LocalFile{
+		Path: "fallback",
+		PathPerPlatform: map[string]string{
+			"linux/amd64": "amd64-bin",
+		},
+	}
+	if got := ResolveLocalFilePath(lf, arm64()); got != "fallback" {
+		t.Errorf("arm64 got %q want fallback", got)
+	}
+}
+
+func TestResolveLocalFilePath_EmptyWhenNothingConfigured(t *testing.T) {
+	if got := ResolveLocalFilePath(LocalFile{}, amd64()); got != "" {
+		t.Errorf("empty config got %q want empty", got)
+	}
+}
+
+func TestResolveLocalFilePath_EmptyWhenNeitherMatches(t *testing.T) {
+	lf := LocalFile{
+		PathPerPlatform: map[string]string{"linux/amd64": "a"},
+	}
+	if got := ResolveLocalFilePath(lf, arm64()); got != "" {
+		t.Errorf("no match got %q want empty", got)
+	}
+}
+
+func TestResolveLocalFilePath_EmptyStringEntryTreatedAsMiss(t *testing.T) {
+	lf := LocalFile{
+		Path: "fallback",
+		PathPerPlatform: map[string]string{
+			"linux/arm64": "",
+		},
+	}
+	if got := ResolveLocalFilePath(lf, arm64()); got != "fallback" {
+		t.Errorf("empty map value should fall through to Path, got %q", got)
+	}
+}
+
+func TestValidateLayers_OK(t *testing.T) {
+	cfg := ContainConfig{Layers: []Layer{
+		{LocalFile: LocalFile{PathPerPlatform: map[string]string{
+			"linux/amd64": "a", "linux/arm64": "b",
+		}}},
+		{LocalDir: LocalDir{Path: "."}},
+	}}
+	if err := ValidateLayers(cfg, []v1.Platform{amd64(), arm64()}); err != nil {
+		t.Errorf("unexpected err: %v", err)
+	}
+}
+
+func TestValidateLayers_MissingPlatform(t *testing.T) {
+	cfg := ContainConfig{Layers: []Layer{
+		{LocalFile: LocalFile{PathPerPlatform: map[string]string{"linux/amd64": "a"}}},
+	}}
+	err := ValidateLayers(cfg, []v1.Platform{amd64(), arm64()})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `layers[0].localFile`) {
+		t.Errorf("error should name the offending layer path, got %q", msg)
+	}
+	if !strings.Contains(msg, "linux/arm64") {
+		t.Errorf("error should name the missing platform, got %q", msg)
+	}
+	if !strings.Contains(msg, `pathPerPlatform["linux/arm64"]`) {
+		t.Errorf("error should suggest the fix, got %q", msg)
+	}
+}
+
+func TestValidateLayers_FallbackCoversMissingPlatform(t *testing.T) {
+	cfg := ContainConfig{Layers: []Layer{
+		{LocalFile: LocalFile{
+			Path:            "fallback",
+			PathPerPlatform: map[string]string{"linux/amd64": "a"},
+		}},
+	}}
+	if err := ValidateLayers(cfg, []v1.Platform{amd64(), arm64()}); err != nil {
+		t.Errorf("fallback should cover missing platform: %v", err)
+	}
+}
+
+func TestValidateLayers_BothLocalFileAndLocalDir(t *testing.T) {
+	cfg := ContainConfig{Layers: []Layer{
+		{LocalFile: LocalFile{Path: "a"}, LocalDir: LocalDir{Path: "b"}},
+	}}
+	err := ValidateLayers(cfg, []v1.Platform{amd64()})
+	if err == nil || !strings.Contains(err.Error(), "exactly one type") {
+		t.Errorf("expected 'exactly one type' error, got %v", err)
+	}
+}
+
+func TestValidateLayers_NeitherLocalFileNorLocalDir(t *testing.T) {
+	cfg := ContainConfig{Layers: []Layer{{}}}
+	err := ValidateLayers(cfg, []v1.Platform{amd64()})
+	if err == nil || !strings.Contains(err.Error(), "no layer builder config found") {
+		t.Errorf("expected 'no layer builder config found' error, got %v", err)
+	}
+}
+
+func TestValidateLayers_InvalidPlatformKey(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{"singlesegment", "linux"},
+		{"trailing-slash", "linux/"},
+		{"leading-slash", "/arm64"},
+		{"four-segments", "linux/arm64/v8/extra"},
+		{"whitespace", "linux /amd64"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := ContainConfig{Layers: []Layer{
+				{LocalFile: LocalFile{
+					Path:            "fallback",
+					PathPerPlatform: map[string]string{tc.key: "x"},
+				}},
+			}}
+			err := ValidateLayers(cfg, []v1.Platform{amd64()})
+			if err == nil || !strings.Contains(err.Error(), "invalid key") {
+				t.Errorf("expected invalid-key error for %q, got %v", tc.key, err)
+			}
+		})
+	}
+}
+
+func TestValidateLayers_ValidVariantKeyAccepted(t *testing.T) {
+	cfg := ContainConfig{Layers: []Layer{
+		{LocalFile: LocalFile{PathPerPlatform: map[string]string{
+			"linux/arm64/v8": "a",
+		}}},
+	}}
+	if err := ValidateLayers(cfg, []v1.Platform{arm64v8()}); err != nil {
+		t.Errorf("3-segment key should be accepted: %v", err)
+	}
+}
+
+func TestValidateLayers_MultipleErrorsJoined(t *testing.T) {
+	cfg := ContainConfig{Layers: []Layer{
+		{LocalFile: LocalFile{PathPerPlatform: map[string]string{"linux/amd64": "a"}}},
+		{LocalFile: LocalFile{PathPerPlatform: map[string]string{"linux/arm64": "b"}}},
+	}}
+	err := ValidateLayers(cfg, []v1.Platform{amd64(), arm64()})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "layers[0]") || !strings.Contains(err.Error(), "layers[1]") {
+		t.Errorf("expected both offending layers in error, got %q", err.Error())
+	}
+}
+
+func TestIsValidPlatformKey_Accepts(t *testing.T) {
+	for _, k := range []string{"linux/amd64", "linux/arm64", "linux/arm64/v8", "windows/amd64"} {
+		if !isValidPlatformKey(k) {
+			t.Errorf("expected %q to be valid", k)
+		}
+	}
+}
+
+func TestIsValidPlatformKey_Rejects(t *testing.T) {
+	for _, k := range []string{"", "linux", "linux/", "/amd64", "linux/amd64/v1/extra", "linux amd64", "linux\tamd64"} {
+		if isValidPlatformKey(k) {
+			t.Errorf("expected %q to be invalid", k)
+		}
+	}
+}


### PR DESCRIPTION
Designed for single-binary CLI: not for `localDir`.